### PR TITLE
Fix biography fields reverting on character sheet

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -156,7 +156,8 @@
     "Errors": {
       "cannotUseWeapon": "Cannot use this weapon - insufficient weapon rank",
       "notEnoughFatePoints": "Not enough Fate Points",
-      "weaponBroken": "Weapon is broken and cannot be used"
+      "weaponBroken": "Weapon is broken and cannot be used",
+      "fieldUpdateFailed": "Failed to update character sheet field."
     }
   },
   "TYPES": {


### PR DESCRIPTION
## Summary
- add explicit change handlers for biography and affinity fields to persist updates without triggering the full auto-submit logic
- normalize values before applying updates and surface a localized error when an update fails
- add a translation string for the new error message

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d46d8e118483339d09c5f312e6c1c0