### PR TITLE
Fix item creation and improve FEUE sheet UX

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -65,7 +65,7 @@ class FireEmblemActor extends Actor {
                 const standard = eq.find(c => c.system.classType === "Standard");
                 const promoted = eq.find(c => c.system.classType === "Promoted");
 
-                baseStats = foundry.utils.deepClone((recruit?.system.baseStats) || (standard?.system.baseStats) || {});
+                baseStats = foundry.utils.deepClone((recruit?.system.baseStats) || (recruit?.system.baseAttributes) || (standard?.system.baseStats) || (standard?.system.baseAttributes) || {});
                 growths = foundry.utils.deepClone((recruit?.system.growthRates) || (standard?.system.growthRates) || {});
                 caps = foundry.utils.deepClone((promoted?.system.statCaps) || (standard?.system.statCaps) || (recruit?.system.statCaps) || {});
             }
@@ -168,6 +168,7 @@ class FireEmblemCharacterSheet extends ActorSheet {
         data.combatArts = this.actor.items.filter(i => i.type === "combatArt");
         data.weapons = this.actor.items.filter(i => i.type === "weapon" || i.type === "battalion");
         data.items = this.actor.items.filter(i => i.type === "item");
+        data.encumbrance = this._getEncumbrance();
 
         // Mark the "equipped" class
         data.equippedClass = data.classes.find(c => c.system.equipped);
@@ -175,9 +176,20 @@ class FireEmblemCharacterSheet extends ActorSheet {
         return data;
     }
 
+    _getEncumbrance() {
+        const items = this.actor.items.filter(i => ["item", "weapon", "battalion"].includes(i.type));
+        const current = items.reduce((sum, i) => sum + ((Number(i.system?.weight) || 0) * (Number(i.system?.quantity) || 1)), 0);
+        const max = (Number(this.actor.system.attributes?.build?.value) || 0) + 10;
+        return { current, max: Math.max(max, 1) };
+    }
+
     activateListeners(html) {
         super.activateListeners(html);
         if (!this.options.editable) return;
+
+        html.find(".level-up").click(async () => this.actor.levelUp());
+
+        html.find(".item-control.item-create").click(async (ev) => this._onItemCreate(ev));
 
         // Generic item controls
         html.find(".item-control.item-edit").click(ev => {
@@ -236,12 +248,35 @@ class FireEmblemCharacterSheet extends ActorSheet {
             await item.update({ "system.equipped": true });
         });
     }
+
+    async _onItemCreate(event) {
+        event.preventDefault();
+        const button = event.currentTarget;
+        const type = button.dataset.type;
+        if (!type) return ui.notifications.error("Missing item type on create button.");
+
+        const itemData = {
+            name: `New ${type.charAt(0).toUpperCase()}${type.slice(1)}`,
+            type
+        };
+        const [created] = await this.actor.createEmbeddedDocuments("Item", [itemData]);
+        if (created) created.sheet.render(true);
+    }
 }
 
 // ====================================================================
 // 4. ITEM CLASS & SHEET
 // ====================================================================
 class FireEmblemItem extends Item {
+    prepareBaseData() {
+        super.prepareBaseData();
+
+        const validTypes = Object.keys(game.system.template.Item || {});
+        if (!this.type && validTypes.length) {
+            this._source.type = validTypes[0];
+        }
+    }
+
     prepareDerivedData() {
         if (this.type === "weapon") {
             // any weapon-specific calc
@@ -347,4 +382,24 @@ Hooks.once("init", () => {
 
 Hooks.once("ready", () => {
     console.log("FEUE | System Ready");
+
+    const itemTemplates = game.system.template.Item || {};
+    const defaultWeaponType = "sword";
+
+    for (const item of game.items.contents) {
+        if (item.type) continue;
+        const fallbackType = Object.keys(itemTemplates)[0] || "item";
+        item.updateSource({ type: fallbackType });
+    }
+
+    const worldWeaponItems = game.items.filter(i => i.type === "weapon");
+    for (const item of worldWeaponItems) {
+        if (!item.system?.weaponType) continue;
+        const normalized = String(item.system.weaponType).toLowerCase();
+        if (FEUE.WeaponTypes[normalized] && normalized !== item.system.weaponType) {
+            item.updateSource({ "system.weaponType": normalized });
+        } else if (!FEUE.WeaponTypes[normalized]) {
+            item.updateSource({ "system.weaponType": defaultWeaponType });
+        }
+    }
 });

--- a/styles/feue.css
+++ b/styles/feue.css
@@ -281,12 +281,46 @@
 
 /* ===== WEAPONS & ITEMS ===== */
 .feue .weapons-section,
-.feue .items-section {
+.feue .items-section,
+.feue .classes-section,
+.feue .skills-section,
+.feue .spells-section,
+.feue .combat-arts-section {
     background: white;
     border: 2px solid var(--feue-border);
     border-radius: 8px;
     padding: 15px;
     margin: 15px 0;
+}
+
+.feue .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    border-bottom: 1px solid rgba(139,115,85,0.35);
+    padding-bottom: 4px;
+}
+
+.feue .section-header h3 {
+    margin: 0;
+}
+
+.feue .item-create {
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+    border: 1px solid var(--feue-primary);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 12px;
+    color: white;
+    background: linear-gradient(180deg, var(--feue-tab-active), var(--feue-primary));
+}
+
+.feue .item-create:hover {
+    text-shadow: none;
+    background: linear-gradient(180deg, #5e83b6, #2f5485);
 }
 
 .feue .item {

--- a/system.json
+++ b/system.json
@@ -18,6 +18,20 @@
   "esmodules": [
     "feue.js"
   ],
+  "documentTypes": {
+    "Actor": {
+      "character": {}
+    },
+    "Item": {
+      "weapon": {},
+      "item": {},
+      "skill": {},
+      "spell": {},
+      "class": {},
+      "battalion": {},
+      "combatArt": {}
+    }
+  },
   "styles": [
     "styles/feue.css"
   ],

--- a/template.json
+++ b/template.json
@@ -134,7 +134,7 @@
     },
     "weapon": {
       "templates": [ "base", "physical" ],
-      "weaponType": "Sword",
+      "weaponType": "sword",
       "might": 5,
       "hit": 90,
       "crit": 0,
@@ -183,7 +183,7 @@
       "equipped": false,
       "unitTypes": {},
       "weaponProficiencies": {},
-      "baseAttributes": {},
+      "baseStats": {},
       "growthRates": {},
       "statCaps": {}
     },

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -145,7 +145,12 @@
 
             {{!-- Equipped Weapons --}}
             <div class="weapons-section">
-                <h3>Weapons</h3>
+                <div class="section-header">
+                    <h3>Weapons</h3>
+                    <a class="item-control item-create" data-type="weapon" title="Create Weapon">
+                        <i class="fas fa-plus"></i> Add Weapon
+                    </a>
+                </div>
                 {{#each weapons as |weapon|}}
                 <div class="item weapon flexrow" data-item-id="{{weapon._id}}">
                     <div class="item-image">
@@ -178,7 +183,12 @@
 
             {{!-- Combat Arts --}}
             <div class="combat-arts-section">
-                <h3>Combat Arts</h3>
+                <div class="section-header">
+                    <h3>Combat Arts</h3>
+                    <a class="item-control item-create" data-type="combatArt" title="Create Combat Art">
+                        <i class="fas fa-plus"></i> Add Combat Art
+                    </a>
+                </div>
                 {{#each combatArts as |art|}}
                 <div class="item combat-art flexrow" data-item-id="{{art._id}}">
                     <div class="item-image">
@@ -211,7 +221,12 @@
             </div>
 
             <div class="items-section">
-                <h3>Items</h3>
+                <div class="section-header">
+                    <h3>Items</h3>
+                    <a class="item-control item-create" data-type="item" title="Create Item">
+                        <i class="fas fa-plus"></i> Add Item
+                    </a>
+                </div>
                 {{#each items as |item|}}
                 <div class="item flexrow" data-item-id="{{item._id}}">
                     <div class="item-image">
@@ -237,7 +252,12 @@
         <div class="tab skills" data-group="primary" data-tab="skills" data-drop-target="true">
             <div class="flexrow">
                 <div class="classes-section flexcol">
-                    <h3>Classes</h3>
+                    <div class="section-header">
+                        <h3>Classes</h3>
+                        <a class="item-control item-create" data-type="class" title="Create Class">
+                            <i class="fas fa-plus"></i> Add Class
+                        </a>
+                    </div>
                     {{#each classes as |class|}}
                     <div class="item class flexrow" data-item-id="{{class._id}}">
                         <div class="item-image">
@@ -263,7 +283,12 @@
                 </div>
 
                 <div class="skills-section flexcol">
-                    <h3>Skills</h3>
+                    <div class="section-header">
+                        <h3>Skills</h3>
+                        <a class="item-control item-create" data-type="skill" title="Create Skill">
+                            <i class="fas fa-plus"></i> Add Skill
+                        </a>
+                    </div>
                     {{#each skills as |skill|}}
                     <div class="item skill flexrow" data-item-id="{{skill._id}}">
                         <div class="item-image">
@@ -287,7 +312,12 @@
             </div>
 
             <div class="spells-section">
-                <h3>Spells</h3>
+                <div class="section-header">
+                    <h3>Spells</h3>
+                    <a class="item-control item-create" data-type="spell" title="Create Spell">
+                        <i class="fas fa-plus"></i> Add Spell
+                    </a>
+                </div>
                 {{#each spells as |spell|}}
                 <div class="item spell flexrow" data-item-id="{{spell._id}}">
                     <div class="item-image">


### PR DESCRIPTION
### Motivation
- Prevent Foundry item-creation failures where `type` was undefined by ensuring actor-sheet create controls always supply a valid `type` and the item document has a safe fallback. 
- Improve the actor sheet UX to feel more Fire Emblem-like by adding explicit Add controls, a Level Up action, and visible encumbrance. 
- Tolerate legacy/incorrect data (legacy `baseAttributes`, non-lowercase weapon types) so older or malformed items don’t break sheets or dropdowns.

### Description
- Add section headers and `Add` buttons for weapons, items, classes, skills, spells and combat arts in `templates/actor/character-sheet.html`, and handle `.item-control.item-create` in the sheet to create embedded items with a valid `type`.
- Implement `_getEncumbrance()` and register a `.level-up` listener in `FireEmblemCharacterSheet` so encumbrance is computed for the inventory tab and `actor.levelUp()` is wired to the sheet button.
- Add `prepareBaseData()` to `FireEmblemItem` to set a fallback `type` when missing and add a `Hooks.once("ready")` normalization pass that assigns missing item `type` values and normalizes `system.weaponType` to the expected lowercase keys.
- Align template defaults by changing `weapon.weaponType` to `"sword"` and renaming `class.baseAttributes` -> `class.baseStats` in `template.json`, declare `documentTypes` in `system.json`, and add CSS for `.section-header` and `.item-create` to improve layout and styling.

### Testing
- Ran `node --check feue.js` successfully with no syntax errors.
- Validated `system.json` and `template.json` using `python -m json.tool` and both passed JSON validation.
- No automated browser/runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69ff8f57c832080a102fde4aa62ff)