### PR TITLE
Inventory & battalion limits, item creation UI, equip logic, weapon-type normalization, and class stat fields

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -6,6 +6,7 @@
 // ====================================================================
 const FEUE = {
     WEAPON_RANKS: {
+        "": { order: -1, label: "—" },
         "E": { order: 0, label: "E" },
         "D": { order: 1, label: "D" },
         "C": { order: 2, label: "C" },
@@ -65,7 +66,7 @@ class FireEmblemActor extends Actor {
                 const standard = eq.find(c => c.system.classType === "Standard");
                 const promoted = eq.find(c => c.system.classType === "Promoted");
 
-                baseStats = foundry.utils.deepClone((recruit?.system.baseStats) || (standard?.system.baseStats) || {});
+                baseStats = foundry.utils.deepClone((recruit?.system.baseStats) || (recruit?.system.baseAttributes) || (standard?.system.baseStats) || (standard?.system.baseAttributes) || {});
                 growths = foundry.utils.deepClone((recruit?.system.growthRates) || (standard?.system.growthRates) || {});
                 caps = foundry.utils.deepClone((promoted?.system.statCaps) || (standard?.system.statCaps) || (recruit?.system.statCaps) || {});
             }
@@ -160,14 +161,17 @@ class FireEmblemCharacterSheet extends ActorSheet {
     getData() {
         const data = super.getData();
         data.FEUE = FEUE;
+        data.weaponRankOptions = Object.entries(FEUE.WEAPON_RANKS).map(([key, value]) => ({ key, label: value.label }));
 
         // Partition items by type
         data.classes = this.actor.items.filter(i => i.type === "class");
         data.skills = this.actor.items.filter(i => i.type === "skill");
         data.spells = this.actor.items.filter(i => i.type === "spell");
         data.combatArts = this.actor.items.filter(i => i.type === "combatArt");
-        data.weapons = this.actor.items.filter(i => i.type === "weapon" || i.type === "battalion");
+        data.weapons = this.actor.items.filter(i => i.type === "weapon");
+        data.battalion = this.actor.items.find(i => i.type === "battalion") || null;
         data.items = this.actor.items.filter(i => i.type === "item");
+        data.inventory = this._getInventoryUsage();
 
         // Mark the "equipped" class
         data.equippedClass = data.classes.find(c => c.system.equipped);
@@ -175,9 +179,18 @@ class FireEmblemCharacterSheet extends ActorSheet {
         return data;
     }
 
+    _getInventoryUsage() {
+        const used = this.actor.items.filter(i => i.type === "item" || i.type === "weapon").length;
+        return { used, max: 5, full: used >= 5 };
+    }
+
     activateListeners(html) {
         super.activateListeners(html);
         if (!this.options.editable) return;
+
+        html.find(".level-up").click(async () => this.actor.levelUp());
+
+        html.find(".item-control.item-create").click(async (ev) => this._onItemCreate(ev));
 
         // Generic item controls
         html.find(".item-control.item-edit").click(ev => {
@@ -200,14 +213,13 @@ class FireEmblemCharacterSheet extends ActorSheet {
         });
 
         // Class equip/unequip
-        html.find(".item-control.item-equip").click(async (ev) => {
+        html.find(".item-control.class-equip").click(async (ev) => {
             const li = $(ev.currentTarget).closest(".item");
             const item = this.actor.items.get(li.data("itemId"));
             if (!item) return;
 
-            const equipped = !item.system.equipped;
-
-            if (equipped) {
+            const currentlyEquipped = !!item.system.equipped;
+            if (currentlyEquipped) {
                 const ok = await Dialog.confirm({
                     title: "Unequip Class",
                     content: "<p>Are you sure? This will erase all class-applied stats, growths, and caps.</p>"
@@ -223,7 +235,7 @@ class FireEmblemCharacterSheet extends ActorSheet {
                 return;
             }
 
-            // Equipping
+            // Equip class
             const t = item.system.classType;
             if (t === "Promoted") {
                 const hasStd = this.actor.items.some(i => i.type === "class" && i.system.equipped && i.system.classType === "Standard");
@@ -235,6 +247,47 @@ class FireEmblemCharacterSheet extends ActorSheet {
             }
             await item.update({ "system.equipped": true });
         });
+
+        // Weapon equip/unequip
+        html.find(".item-control.weapon-equip").click(async (ev) => {
+            const li = $(ev.currentTarget).closest(".item");
+            const item = this.actor.items.get(li.data("itemId"));
+            if (!item || item.type !== "weapon") return;
+
+            const currentlyEquipped = !!item.system.equipped;
+            if (currentlyEquipped) {
+                await item.update({ "system.equipped": false });
+                return;
+            }
+
+            const equippedWeapons = this.actor.items.filter(i => i.type === "weapon" && i.system.equipped && i.id !== item.id);
+            if (equippedWeapons.length) {
+                await this.actor.updateEmbeddedDocuments("Item", equippedWeapons.map(w => ({ _id: w.id, "system.equipped": false })));
+            }
+            await item.update({ "system.equipped": true });
+        });
+    }
+
+    async _onItemCreate(event) {
+        event.preventDefault();
+        const button = event.currentTarget;
+        const type = button.dataset.type;
+        if (!type) return ui.notifications.error("Missing item type on create button.");
+
+        const inventory = this._getInventoryUsage();
+        if ((type === "item" || type === "weapon") && inventory.full) {
+            return ui.notifications.error("Inventory full: characters can only hold 5 total weapons/items.");
+        }
+        if (type === "battalion" && this.actor.items.some(i => i.type === "battalion")) {
+            return ui.notifications.error("Characters can only have one battalion.");
+        }
+
+        const itemData = {
+            name: `New ${type.charAt(0).toUpperCase()}${type.slice(1)}`,
+            type
+        };
+        const [created] = await this.actor.createEmbeddedDocuments("Item", [itemData]);
+        if (created) created.sheet.render(true);
     }
 }
 
@@ -347,4 +400,42 @@ Hooks.once("init", () => {
 
 Hooks.once("ready", () => {
     console.log("FEUE | System Ready");
+
+    const defaultWeaponType = "sword";
+
+    const worldWeaponItems = game.items.filter(i => i.type === "weapon");
+    for (const item of worldWeaponItems) {
+        if (!item.system?.weaponType) continue;
+        const normalized = String(item.system.weaponType).toLowerCase();
+        if (FEUE.WeaponTypes[normalized] && normalized !== item.system.weaponType) {
+            item.updateSource({ "system.weaponType": normalized });
+        } else if (!FEUE.WeaponTypes[normalized]) {
+            item.updateSource({ "system.weaponType": defaultWeaponType });
+        }
+    }
+});
+
+Hooks.on("preCreateItem", (item, createData) => {
+    const parent = item.parent;
+    if (!parent || parent.documentName !== "Actor") return true;
+
+    const type = createData.type ?? item.type;
+    if (!type) return false;
+
+    if (type === "item" || type === "weapon") {
+        const used = parent.items.filter(i => i.type === "item" || i.type === "weapon").length;
+        if (used >= 5) {
+            ui.notifications.error(`${parent.name} is at the 5-slot inventory limit (weapons/items).`);
+            return false;
+        }
+    }
+
+    if (type === "battalion") {
+        const hasBattalion = parent.items.some(i => i.type === "battalion");
+        if (hasBattalion) {
+            ui.notifications.error(`${parent.name} can only have one battalion.`);
+            return false;
+        }
+    }
+    return true;
 });

--- a/styles/feue.css
+++ b/styles/feue.css
@@ -281,12 +281,60 @@
 
 /* ===== WEAPONS & ITEMS ===== */
 .feue .weapons-section,
-.feue .items-section {
+.feue .items-section,
+.feue .classes-section,
+.feue .skills-section,
+.feue .spells-section,
+.feue .combat-arts-section,
+.feue .battalion-section,
+.feue .inventory-limit {
     background: white;
     border: 2px solid var(--feue-border);
     border-radius: 8px;
     padding: 15px;
     margin: 15px 0;
+}
+
+.feue .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    border-bottom: 1px solid rgba(139,115,85,0.35);
+    padding-bottom: 4px;
+}
+
+.feue .section-header h3 {
+    margin: 0;
+}
+
+.feue .item-create {
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+    border: 1px solid var(--feue-primary);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 12px;
+    color: white;
+    background: linear-gradient(180deg, var(--feue-tab-active), var(--feue-primary));
+}
+
+.feue .item-create:hover {
+    text-shadow: none;
+    background: linear-gradient(180deg, #5e83b6, #2f5485);
+}
+
+.feue .item-create.disabled {
+    opacity: 0.6;
+}
+
+.feue .limit-note,
+.feue .empty-note,
+.feue .inventory-limit p {
+    color: var(--feue-secondary);
+    font-style: italic;
+    margin: 0;
 }
 
 .feue .item {

--- a/system.json
+++ b/system.json
@@ -18,6 +18,20 @@
   "esmodules": [
     "feue.js"
   ],
+  "documentTypes": {
+    "Actor": [
+      "character"
+    ],
+    "Item": [
+      "weapon",
+      "item",
+      "skill",
+      "spell",
+      "class",
+      "battalion",
+      "combatArt"
+    ]
+  },
   "styles": [
     "styles/feue.css"
   ],

--- a/template.json
+++ b/template.json
@@ -134,7 +134,7 @@
     },
     "weapon": {
       "templates": [ "base", "physical" ],
-      "weaponType": "Sword",
+      "weaponType": "sword",
       "might": 5,
       "hit": 90,
       "crit": 0,
@@ -183,7 +183,7 @@
       "equipped": false,
       "unitTypes": {},
       "weaponProficiencies": {},
-      "baseAttributes": {},
+      "baseStats": {},
       "growthRates": {},
       "statCaps": {}
     },

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -81,8 +81,8 @@
                     <div class="weapon-rank-row flexrow">
                         <label class="weapon-label">{{weapon}}</label>
                         <select class="weapon-rank-select" name="system.weaponRanks.{{weapon}}" data-weapon-type="{{weapon}}">
-                            {{#each FEUE.WEAPON_RANKS as |rankData rankKey|}}
-                            <option value="{{rankKey}}" {{#ifEquals rank rankKey}} selected{{/ifEquals}}>{{rankData.label}}</option>
+                            {{#each ../weaponRankOptions as |opt|}}
+                            <option value="{{opt.key}}" {{#ifEquals rank opt.key}} selected{{/ifEquals}}>{{opt.label}}</option>
                             {{/each}}
                         </select>
                     </div>
@@ -145,7 +145,12 @@
 
             {{!-- Equipped Weapons --}}
             <div class="weapons-section">
-                <h3>Weapons</h3>
+                <div class="section-header">
+                    <h3>Weapons</h3>
+                    <a class="item-control item-create {{#if inventory.full}}disabled{{/if}}" data-type="weapon" title="Create Weapon">
+                        <i class="fas fa-plus"></i> Add Weapon
+                    </a>
+                </div>
                 {{#each weapons as |weapon|}}
                 <div class="item weapon flexrow" data-item-id="{{weapon._id}}">
                     <div class="item-image">
@@ -159,7 +164,7 @@
                         <span>{{weapon.system.range}} Rng</span>
                     </div>
                     <div class="item-controls">
-                        <a class="item-control item-equip" title="{{#if weapon.system.equipped}}Unequip{{else}}Equip{{/if}}">
+                        <a class="item-control weapon-equip" title="{{#if weapon.system.equipped}}Unequip{{else}}Equip{{/if}}">
                             <i class="fas {{#if weapon.system.equipped}}fa-shield-alt{{else}}fa-hand-paper{{/if}}"></i>
                         </a>
                         <a class="item-control roll-attack" data-weapon-id="{{weapon._id}}" title="Attack">
@@ -176,9 +181,50 @@
                 {{/each}}
             </div>
 
+            <div class="battalion-section">
+                <div class="section-header">
+                    <h3>Battalion</h3>
+                    {{#if battalion}}
+                    <span class="limit-note">1 / 1</span>
+                    {{else}}
+                    <a class="item-control item-create" data-type="battalion" title="Create Battalion">
+                        <i class="fas fa-plus"></i> Add Battalion
+                    </a>
+                    {{/if}}
+                </div>
+                {{#if battalion}}
+                <div class="item battalion flexrow" data-item-id="{{battalion._id}}">
+                    <div class="item-image">
+                        <img src="{{battalion.img}}" title="{{battalion.name}}" width="24" height="24" />
+                    </div>
+                    <h4 class="item-name">{{battalion.name}}</h4>
+                    <div class="weapon-stats">
+                        <span>{{battalion.system.might}} Mt</span>
+                        <span>{{battalion.system.hit}} Hit</span>
+                        <span>{{battalion.system.range}} Rng</span>
+                    </div>
+                    <div class="item-controls">
+                        <a class="item-control item-edit" title="Edit Battalion">
+                            <i class="fas fa-edit"></i>
+                        </a>
+                        <a class="item-control item-delete" title="Delete Battalion">
+                            <i class="fas fa-trash"></i>
+                        </a>
+                    </div>
+                </div>
+                {{else}}
+                <p class="empty-note">No battalion assigned.</p>
+                {{/if}}
+            </div>
+
             {{!-- Combat Arts --}}
             <div class="combat-arts-section">
-                <h3>Combat Arts</h3>
+                <div class="section-header">
+                    <h3>Combat Arts</h3>
+                    <a class="item-control item-create" data-type="combatArt" title="Create Combat Art">
+                        <i class="fas fa-plus"></i> Add Combat Art
+                    </a>
+                </div>
                 {{#each combatArts as |art|}}
                 <div class="item combat-art flexrow" data-item-id="{{art._id}}">
                     <div class="item-image">
@@ -203,15 +249,18 @@
 
         {{!-- Inventory Tab --}}
         <div class="tab inventory" data-group="primary" data-tab="inventory" data-drop-target="true">
-            <div class="encumbrance">
-                <h3>Encumbrance: {{encumbrance.current}}/{{encumbrance.max}}</h3>
-                <div class="encumbrance-bar">
-                    <div class="encumbrance-fill" style="width: {{math encumbrance.current '/' encumbrance.max '*' 100}}%"></div>
-                </div>
+            <div class="inventory-limit">
+                <h3>Inventory Slots: {{inventory.used}} / {{inventory.max}}</h3>
+                <p>Limit applies to Weapons + Items only. Battalion is tracked separately.</p>
             </div>
 
             <div class="items-section">
-                <h3>Items</h3>
+                <div class="section-header">
+                    <h3>Items</h3>
+                    <a class="item-control item-create {{#if inventory.full}}disabled{{/if}}" data-type="item" title="Create Item">
+                        <i class="fas fa-plus"></i> Add Item
+                    </a>
+                </div>
                 {{#each items as |item|}}
                 <div class="item flexrow" data-item-id="{{item._id}}">
                     <div class="item-image">
@@ -237,7 +286,12 @@
         <div class="tab skills" data-group="primary" data-tab="skills" data-drop-target="true">
             <div class="flexrow">
                 <div class="classes-section flexcol">
-                    <h3>Classes</h3>
+                    <div class="section-header">
+                        <h3>Classes</h3>
+                        <a class="item-control item-create" data-type="class" title="Create Class">
+                            <i class="fas fa-plus"></i> Add Class
+                        </a>
+                    </div>
                     {{#each classes as |class|}}
                     <div class="item class flexrow" data-item-id="{{class._id}}">
                         <div class="item-image">
@@ -248,7 +302,7 @@
                             <p class="class-details">{{class.system.classType}} | Max Lv {{class.system.maxLevel}}</p>
                         </div>
                         <div class="item-controls">
-                            <a class="item-control item-equip {{#if class.system.equipped}}equipped{{/if}}" title="{{#if class.system.equipped}}Unequip{{else}}Equip{{/if}}">
+                            <a class="item-control class-equip {{#if class.system.equipped}}equipped{{/if}}" title="{{#if class.system.equipped}}Unequip{{else}}Equip{{/if}}">
                                 <i class="fas {{#if class.system.equipped}}fa-shield-alt{{else}}fa-hand-paper{{/if}}"></i>
                             </a>
                             <a class="item-control item-edit" title="Edit Class">
@@ -263,7 +317,12 @@
                 </div>
 
                 <div class="skills-section flexcol">
-                    <h3>Skills</h3>
+                    <div class="section-header">
+                        <h3>Skills</h3>
+                        <a class="item-control item-create" data-type="skill" title="Create Skill">
+                            <i class="fas fa-plus"></i> Add Skill
+                        </a>
+                    </div>
                     {{#each skills as |skill|}}
                     <div class="item skill flexrow" data-item-id="{{skill._id}}">
                         <div class="item-image">
@@ -287,7 +346,12 @@
             </div>
 
             <div class="spells-section">
-                <h3>Spells</h3>
+                <div class="section-header">
+                    <h3>Spells</h3>
+                    <a class="item-control item-create" data-type="spell" title="Create Spell">
+                        <i class="fas fa-plus"></i> Add Spell
+                    </a>
+                </div>
                 {{#each spells as |spell|}}
                 <div class="item spell flexrow" data-item-id="{{spell._id}}">
                     <div class="item-image">

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -392,6 +392,60 @@
                     {{/each}}
                 </div>
             </div>
+
+            <div class="form-group">
+                <h3>Base Stats</h3>
+                <div class="form-row">
+                    <div class="form-group"><label>HP</label><input type="number" data-dtype="Number" name="system.baseStats.hp" value="{{item.system.baseStats.hp}}" /></div>
+                    <div class="form-group"><label>Str</label><input type="number" data-dtype="Number" name="system.baseStats.strength" value="{{item.system.baseStats.strength}}" /></div>
+                    <div class="form-group"><label>Mag</label><input type="number" data-dtype="Number" name="system.baseStats.magic" value="{{item.system.baseStats.magic}}" /></div>
+                    <div class="form-group"><label>Skl</label><input type="number" data-dtype="Number" name="system.baseStats.skill" value="{{item.system.baseStats.skill}}" /></div>
+                    <div class="form-group"><label>Spd</label><input type="number" data-dtype="Number" name="system.baseStats.speed" value="{{item.system.baseStats.speed}}" /></div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group"><label>Def</label><input type="number" data-dtype="Number" name="system.baseStats.defense" value="{{item.system.baseStats.defense}}" /></div>
+                    <div class="form-group"><label>Res</label><input type="number" data-dtype="Number" name="system.baseStats.resistance" value="{{item.system.baseStats.resistance}}" /></div>
+                    <div class="form-group"><label>Lck</label><input type="number" data-dtype="Number" name="system.baseStats.luck" value="{{item.system.baseStats.luck}}" /></div>
+                    <div class="form-group"><label>Cha</label><input type="number" data-dtype="Number" name="system.baseStats.charm" value="{{item.system.baseStats.charm}}" /></div>
+                    <div class="form-group"><label>Bld</label><input type="number" data-dtype="Number" name="system.baseStats.build" value="{{item.system.baseStats.build}}" /></div>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <h3>Growth Rates</h3>
+                <div class="form-row">
+                    <div class="form-group"><label>HP</label><input type="number" data-dtype="Number" name="system.growthRates.hp" value="{{item.system.growthRates.hp}}" /></div>
+                    <div class="form-group"><label>Str</label><input type="number" data-dtype="Number" name="system.growthRates.strength" value="{{item.system.growthRates.strength}}" /></div>
+                    <div class="form-group"><label>Mag</label><input type="number" data-dtype="Number" name="system.growthRates.magic" value="{{item.system.growthRates.magic}}" /></div>
+                    <div class="form-group"><label>Skl</label><input type="number" data-dtype="Number" name="system.growthRates.skill" value="{{item.system.growthRates.skill}}" /></div>
+                    <div class="form-group"><label>Spd</label><input type="number" data-dtype="Number" name="system.growthRates.speed" value="{{item.system.growthRates.speed}}" /></div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group"><label>Def</label><input type="number" data-dtype="Number" name="system.growthRates.defense" value="{{item.system.growthRates.defense}}" /></div>
+                    <div class="form-group"><label>Res</label><input type="number" data-dtype="Number" name="system.growthRates.resistance" value="{{item.system.growthRates.resistance}}" /></div>
+                    <div class="form-group"><label>Lck</label><input type="number" data-dtype="Number" name="system.growthRates.luck" value="{{item.system.growthRates.luck}}" /></div>
+                    <div class="form-group"><label>Cha</label><input type="number" data-dtype="Number" name="system.growthRates.charm" value="{{item.system.growthRates.charm}}" /></div>
+                    <div class="form-group"><label>Bld</label><input type="number" data-dtype="Number" name="system.growthRates.build" value="{{item.system.growthRates.build}}" /></div>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <h3>Stat Caps</h3>
+                <div class="form-row">
+                    <div class="form-group"><label>HP</label><input type="number" data-dtype="Number" name="system.statCaps.hp" value="{{item.system.statCaps.hp}}" /></div>
+                    <div class="form-group"><label>Str</label><input type="number" data-dtype="Number" name="system.statCaps.strength" value="{{item.system.statCaps.strength}}" /></div>
+                    <div class="form-group"><label>Mag</label><input type="number" data-dtype="Number" name="system.statCaps.magic" value="{{item.system.statCaps.magic}}" /></div>
+                    <div class="form-group"><label>Skl</label><input type="number" data-dtype="Number" name="system.statCaps.skill" value="{{item.system.statCaps.skill}}" /></div>
+                    <div class="form-group"><label>Spd</label><input type="number" data-dtype="Number" name="system.statCaps.speed" value="{{item.system.statCaps.speed}}" /></div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group"><label>Def</label><input type="number" data-dtype="Number" name="system.statCaps.defense" value="{{item.system.statCaps.defense}}" /></div>
+                    <div class="form-group"><label>Res</label><input type="number" data-dtype="Number" name="system.statCaps.resistance" value="{{item.system.statCaps.resistance}}" /></div>
+                    <div class="form-group"><label>Lck</label><input type="number" data-dtype="Number" name="system.statCaps.luck" value="{{item.system.statCaps.luck}}" /></div>
+                    <div class="form-group"><label>Cha</label><input type="number" data-dtype="Number" name="system.statCaps.charm" value="{{item.system.statCaps.charm}}" /></div>
+                    <div class="form-group"><label>Bld</label><input type="number" data-dtype="Number" name="system.statCaps.build" value="{{item.system.statCaps.build}}" /></div>
+                </div>
+            </div>
         </div>
         {{/if}}
 


### PR DESCRIPTION
### Motivation
- Enforce an inventory size limit for weapons/items and a single battalion per character, and surface that constraint in the character UI.  
- Provide in-sheet creation controls for items, weapons, battalions, skills, spells, classes, and combat arts and prevent invalid creation server-side.  
- Normalize world `weaponType` values and provide a sane default to avoid mismatched names.  
- Add explicit `baseStats`, `growthRates`, and `statCaps` editing for class items and improve weapon-rank handling in the UI.

### Description
- Updated `feue.js` to add an empty weapon-rank option to `FEUE.WEAPON_RANKS`, expose `weaponRankOptions` to the sheet, and accept `baseAttributes` as a fallback when resolving class base stats.  
- Implemented inventory tracking with `_getInventoryUsage`, added inline create buttons and client-side create guards in the character sheet, and added class/weapon equip handlers (`class-equip`, `weapon-equip`) with proper equip/unequip semantics and confirmation on unequip.  
- Added server-side enforcement via a `Hooks.on("preCreateItem")` to block creating extra weapons/items beyond the 5-slot limit and to prevent more than one `battalion`, and added a `ready` hook to normalize existing world `weapon` items `system.weaponType` values (defaulting to `sword`).  
- Template and stylesheet updates: split `weapon` vs `battalion` in the actor template, added inventory/battalion UI sections and `item-create` controls, updated class/item templates to include `baseStats`, `growthRates`, and `statCaps` fields, and added new CSS for section headers, create buttons, and inventory notes.  
- `system.json` now declares `documentTypes` for `Actor` and `Item`, and `template.json` defaults `weapon.weaponType` to `sword` and renames the class template key to `baseStats`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69ff8f57c832080a102fde4aa62ff)