### PR TITLE
Apply promotion benefits and convert promotion tree to nested UI

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -68,6 +68,7 @@ class FireEmblemActor extends Actor {
             name: classItem.name, classType: sys.classType, movement: sys.movement,
             maxLevel: sys.maxLevel, baseStats: sys.baseStats || {},
             growthRates: sys.growthRates || {}, statCaps: sys.statCaps || {},
+            unitTypes: sys.unitTypes || {}, weaponProficiencies: sys.weaponProficiencies || {},
             promotions: sys.promotions || []
         };
         for (const id of (sys.currentPath || [])) {
@@ -196,10 +197,11 @@ class FireEmblemActor extends Actor {
                         const id = html.find("#feue-promo-choice").val();
                         const chosen = promotions.find(p => p.id === id);
                         if (!chosen) return;
+                        const previousNode = this._getCurrentClassNode(classItem);
                         const newPath = [...(classItem.system.currentPath || []), id];
                         await classItem.update({ "system.currentPath": newPath });
+                        await this._applyPromotionBenefits(previousNode, chosen);
                         await this.update({ "system.level": 1 });
-                        if (chosen.baseStats?.hp) await this.update({ "system.attributes.hp.max": chosen.baseStats.hp, "system.attributes.hp.value": chosen.baseStats.hp });
                         ui.notifications.info(`${this.name} promoted to ${chosen.name}!`);
                         ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this }), content: `<div class="feue-levelup"><h3>${this.name} promoted to ${chosen.name}!</h3></div>` });
                     }
@@ -207,6 +209,51 @@ class FireEmblemActor extends Actor {
                 wait: { icon: '<i class="fas fa-clock"></i>', label: "Not Yet" }
             }, default: "wait"
         }).render(true);
+    }
+
+    async _applyPromotionBenefits(previousNode, chosenNode) {
+        const prevType = previousNode?.classType || "";
+        const nextType = chosenNode?.classType || "";
+        const promoteToAdvanced = ["Promoted", "Advanced"].includes(nextType);
+        const fromBaseClass = ["Recruit", "Standard"].includes(prevType);
+        const updates = {};
+
+        for (const key of FEUE.STAT_KEYS) {
+            const current = key === "hp"
+                ? Number(this.system.attributes?.hp?.max || 0)
+                : Number(this.system.attributes?.[key]?.value || 0);
+            const nextBase = Number(chosenNode?.baseStats?.[key] || 0);
+            const prevBase = Number(previousNode?.baseStats?.[key] || 0);
+            let result = current;
+
+            // Recruit/Standard promotions floor to the target class base.
+            if (fromBaseClass && !promoteToAdvanced) result = Math.max(current, nextBase);
+
+            // Standard->Promoted/Advanced applies stat bonuses from class-base deltas.
+            if (promoteToAdvanced) result = current + Math.max(nextBase - prevBase, 0);
+
+            if (key === "hp") {
+                const diff = result - current;
+                updates["system.attributes.hp.max"] = result;
+                updates["system.attributes.hp.value"] = Math.max(0, Number(this.system.attributes?.hp?.value || 0) + diff);
+            } else {
+                updates[`system.attributes.${key}.value`] = result;
+            }
+        }
+
+        const unitTypes = Object.entries(chosenNode?.unitTypes || {})
+            .filter(([, enabled]) => Boolean(enabled))
+            .map(([name]) => name);
+        updates["system.unitTypes"] = unitTypes;
+
+        const existingRanks = this.system.weaponRanks || {};
+        for (const wt of Object.keys(FEUE.WeaponTypes)) {
+            if (chosenNode?.weaponProficiencies?.[wt] && !existingRanks[wt]) {
+                updates[`system.weaponRanks.${wt}`] = "E";
+            }
+        }
+
+        await this.update(updates);
     }
 
     canUseWeapon(weapon) {
@@ -459,22 +506,32 @@ class FireEmblemItemSheet extends ItemSheet {
         const c = html.find("#promotion-tree-container");
         if (!c.length) return;
         const promos = this.item.system.promotions || [];
-        c.html(promos.length ? this._buildTreeHTML(promos, 0, []) : '<p style="color:#8b4513; font-style:italic;">No promotions defined.</p>');
+        const currentPath = this.item.system.currentPath || [];
+        c.html(promos.length ? this._buildTreeHTML(promos, [], currentPath) : '<p style="color:#8b4513; font-style:italic;">No promotions defined.</p>');
     }
 
-    _buildTreeHTML(promos, depth, parentPath) {
-        let html = '';
+    _buildTreeHTML(promos, parentPath, currentPath) {
+        let html = '<ul class="promo-tree-list">';
         for (const p of promos) {
-            const path = [...parentPath, p.id].join(",");
+            const nodePath = [...parentPath, p.id];
+            const path = nodePath.join(",");
             const isProm = ["Promoted", "Advanced"].includes(p.classType);
-            html += `<div style="margin-left:${depth * 24}px; display:flex; align-items:center; gap:8px; padding:4px 8px; margin:3px 0; background:#f9f9f9; border:1px solid #8b7355; border-radius:4px;">
-                <span style="flex:1;"><b>${p.name}</b> <span style="color:${isProm ? "#8b4513" : "#2c4875"}; font-size:11px;">(${p.classType})</span></span>
-                <a class="promo-edit" data-path="${path}" title="Edit" style="cursor:pointer;"><i class="fas fa-edit"></i></a>
-                <a class="promo-delete" data-path="${path}" title="Delete" style="cursor:pointer;color:#a0522d;"><i class="fas fa-trash"></i></a>
-                <a class="promo-add-sub" data-path="${path}" title="Add Sub-Promotion" style="cursor:pointer;color:#2c4875;"><i class="fas fa-plus"></i></a>
-            </div>`;
-            if (p.promotions?.length) html += this._buildTreeHTML(p.promotions, depth + 1, [...parentPath, p.id]);
+            const checked = nodePath.length === currentPath.length && nodePath.every((id, idx) => id === currentPath[idx]);
+            html += `<li class="promo-tree-node${checked ? " is-selected" : ""}">
+                <div class="promo-tree-row">
+                    <span class="promo-tree-label" style="color:${isProm ? "#8b4513" : "#2c4875"};">
+                        <b>${p.name}</b>
+                        <span class="promo-tree-type">(${p.classType})</span>
+                        ${checked ? '<span class="promo-tree-check"><i class="fas fa-check-circle"></i> Active</span>' : ""}
+                    </span>
+                    <a class="promo-edit" data-path="${path}" title="Edit" style="cursor:pointer;"><i class="fas fa-edit"></i></a>
+                    <a class="promo-delete" data-path="${path}" title="Delete" style="cursor:pointer;color:#a0522d;"><i class="fas fa-trash"></i></a>
+                    <a class="promo-add-sub" data-path="${path}" title="Add Sub-Promotion" style="cursor:pointer;color:#2c4875;"><i class="fas fa-plus"></i></a>
+                </div>
+                ${p.promotions?.length ? this._buildTreeHTML(p.promotions, nodePath, currentPath) : ""}
+            </li>`;
         }
+        html += "</ul>";
         return html;
     }
 
@@ -525,6 +582,10 @@ class FireEmblemItemSheet extends ItemSheet {
         const isProm = ["Promoted", "Advanced"].includes(promo.classType);
         const bs = promo.baseStats || {}, gr = promo.growthRates || {}, sc = promo.statCaps || {};
         const sr = (pfx, obj) => FEUE.STAT_KEYS.map(k => `<div style="display:inline-block;width:18%;margin:2px;"><label style="font-size:11px;">${FEUE.STAT_LABELS[k]}</label><input type="number" data-key="${pfx}.${k}" value="${obj[k] || 0}" style="width:100%;"/></div>`).join("");
+        const unitTypes = promo.unitTypes || {};
+        const weaponProficiencies = promo.weaponProficiencies || {};
+        const unitTypeChecks = FEUE.UNIT_TYPES.map(type => `<label style="display:inline-flex;align-items:center;gap:4px;margin-right:10px;"><input type="checkbox" data-key="ut.${type}" ${unitTypes[type] ? "checked" : ""}/> ${type}</label>`).join("");
+        const weaponChecks = Object.entries(FEUE.WeaponTypes).map(([key, label]) => `<label style="display:inline-flex;align-items:center;gap:4px;margin-right:10px;"><input type="checkbox" data-key="wp.${key}" ${weaponProficiencies[key] ? "checked" : ""}/> ${label}</label>`).join("");
 
         new Dialog({
             title: `Edit: ${promo.name}`,
@@ -532,6 +593,8 @@ class FireEmblemItemSheet extends ItemSheet {
                 <div class="form-group"><label>Name</label><input type="text" id="pn" value="${promo.name}"/></div>
                 <div class="form-group"><label>Class Type</label><select id="pct">${FEUE.CLASS_TYPES.map(t => `<option value="${t}" ${promo.classType === t ? "selected" : ""}>${t}</option>`).join("")}</select></div>
                 <div style="display:flex;gap:8px;"><div class="form-group" style="flex:1;"><label>Max Level</label><input type="number" id="pml" value="${promo.maxLevel || 20}"/></div><div class="form-group" style="flex:1;"><label>Movement</label><input type="number" id="pmv" value="${promo.movement || 5}"/></div></div>
+                <hr/><h4>Unit Types</h4><div>${unitTypeChecks}</div>
+                <hr/><h4>Weapon Proficiencies</h4><div>${weaponChecks}</div>
                 <hr/><div id="pbs" ${isProm ? 'style="display:none;"' : ''}><h4>Base Stats</h4><div>${sr("bs", bs)}</div><hr/></div>
                 <h4>Growth Rates</h4><div>${sr("gr", gr)}</div><hr/>
                 <h4>Stat Caps</h4><div>${sr("sc", sc)}</div></form>`,
@@ -540,9 +603,11 @@ class FireEmblemItemSheet extends ItemSheet {
                     icon: '<i class="fas fa-save"></i>', label: "Save", callback: (h) => {
                         const d = {
                             id: promo.id, name: h.find("#pn").val() || "Unnamed", classType: h.find("#pct").val(), maxLevel: Number(h.find("#pml").val()) || 20, movement: Number(h.find("#pmv").val()) || 5,
-                            unitTypes: promo.unitTypes || {}, weaponProficiencies: promo.weaponProficiencies || {}, baseStats: {}, growthRates: {}, statCaps: {}, promotions: promo.promotions || []
+                            unitTypes: {}, weaponProficiencies: {}, baseStats: {}, growthRates: {}, statCaps: {}, promotions: promo.promotions || []
                         };
-                        h.find("input[data-key]").each((_, el) => { const [g, s] = el.dataset.key.split("."); const map = { bs: "baseStats", gr: "growthRates", sc: "statCaps" }; d[map[g]][s] = Number(el.value) || 0; });
+                        h.find("input[type='number'][data-key]").each((_, el) => { const [g, s] = el.dataset.key.split("."); const map = { bs: "baseStats", gr: "growthRates", sc: "statCaps" }; d[map[g]][s] = Number(el.value) || 0; });
+                        h.find("input[type='checkbox'][data-key^='ut.']").each((_, el) => { const key = el.dataset.key.slice(3); d.unitTypes[key] = el.checked; });
+                        h.find("input[type='checkbox'][data-key^='wp.']").each((_, el) => { const key = el.dataset.key.slice(3); d.weaponProficiencies[key] = el.checked; });
                         onSave(d);
                     }
                 }, cancel: { label: "Cancel" }

--- a/styles/feue.css
+++ b/styles/feue.css
@@ -248,6 +248,50 @@
     background: white;
 }
 
+/* ===== PROMOTION TREE ===== */
+.promo-tree-list {
+    list-style: none;
+    margin: 0 0 0 14px;
+    padding: 0 0 0 12px;
+    border-left: 1px solid rgba(44, 72, 117, 0.35);
+}
+
+.promo-tree-node {
+    margin: 6px 0;
+}
+
+.promo-tree-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border: 1px solid var(--feue-border);
+    border-radius: 4px;
+    background: #f9f9f9;
+}
+
+.promo-tree-label {
+    flex: 1;
+}
+
+.promo-tree-type {
+    font-size: 11px;
+}
+
+.promo-tree-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+    font-size: 11px;
+    color: #1f6b2c;
+}
+
+.promo-tree-node.is-selected .promo-tree-row {
+    background: #edf8ef;
+    border-color: #2e7d32;
+}
+
 /* ===== COMBAT STATS ===== */
 .feue .combat-stats {
     background: white;


### PR DESCRIPTION
### Motivation
- Ensure promotions actually apply the intended class effects (stat changes, HP, unit types, weapon proficiencies) when a branch is chosen rather than only updating the class path. 
- Support realistic differences between base-class promotions (floor to target base) and promoted/advanced transitions (apply base-delta bonuses). 
- Make the promotion editor display the promotion tree as a real nested tree and clearly show the active branch. 

### Description
- Update class-node resolution to include `unitTypes` and `weaponProficiencies` so promotion nodes carry those values when active. 
- Add `_applyPromotionBenefits(previousNode, chosenNode)` to: floor Recruit/Standard promotions to the target base, add stat bonuses for Standard→Promoted/Advanced based on base-stat deltas, adjust HP max/current for promotion gains, sync `system.unitTypes`, and grant missing weapon ranks (set to `E`) for newly unlocked proficiencies. 
- Call `_applyPromotionBenefits` when the promotion dialog chooses a branch so benefits are applied immediately, then reset `system.level` to 1. 
- Replace the flat promotion list rendering with a nested `ul/li` tree that highlights the active node and display an active check marker, and add unit-type and weapon-proficiency checkboxes to the promotion edit dialog; also add supporting CSS for the tree. 

### Testing
- Ran a syntax check with `node --check feue.js`, which completed successfully. 
- No other automated tests were present or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f47726988320b3b18b32aee28308)