### PR TITLE
Apply promotion benefits, enhance promotion tree UI, and add weapon-rank visibility toggle

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -31,6 +31,10 @@ const FEUE = {
 const DEFAULT_WEAPON_RANKS = Object.fromEntries(
     Object.keys(FEUE.WeaponTypes).map(type => [type, ""])
 );
+const CLASS_TYPE_ORDER = FEUE.CLASS_TYPES.reduce((out, type, index) => {
+    out[type] = index;
+    return out;
+}, {});
 
 // ====================================================================
 // 2. ACTOR CLASS
@@ -68,6 +72,7 @@ class FireEmblemActor extends Actor {
             name: classItem.name, classType: sys.classType, movement: sys.movement,
             maxLevel: sys.maxLevel, baseStats: sys.baseStats || {},
             growthRates: sys.growthRates || {}, statCaps: sys.statCaps || {},
+            unitTypes: sys.unitTypes || {}, weaponProficiencies: sys.weaponProficiencies || {},
             promotions: sys.promotions || []
         };
         for (const id of (sys.currentPath || [])) {
@@ -196,10 +201,11 @@ class FireEmblemActor extends Actor {
                         const id = html.find("#feue-promo-choice").val();
                         const chosen = promotions.find(p => p.id === id);
                         if (!chosen) return;
+                        const previousNode = this._getCurrentClassNode(classItem);
                         const newPath = [...(classItem.system.currentPath || []), id];
                         await classItem.update({ "system.currentPath": newPath });
+                        await this._applyPromotionBenefits(previousNode, chosen);
                         await this.update({ "system.level": 1 });
-                        if (chosen.baseStats?.hp) await this.update({ "system.attributes.hp.max": chosen.baseStats.hp, "system.attributes.hp.value": chosen.baseStats.hp });
                         ui.notifications.info(`${this.name} promoted to ${chosen.name}!`);
                         ChatMessage.create({ user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this }), content: `<div class="feue-levelup"><h3>${this.name} promoted to ${chosen.name}!</h3></div>` });
                     }
@@ -207,6 +213,50 @@ class FireEmblemActor extends Actor {
                 wait: { icon: '<i class="fas fa-clock"></i>', label: "Not Yet" }
             }, default: "wait"
         }).render(true);
+    }
+
+    async _applyPromotionBenefits(previousNode, chosenNode) {
+        const prevType = previousNode?.classType || "";
+        const nextType = chosenNode?.classType || "";
+        const promoteToAdvanced = ["Promoted", "Advanced"].includes(nextType);
+        const fromBaseClass = ["Recruit", "Standard"].includes(prevType);
+        const updates = {};
+
+        for (const key of FEUE.STAT_KEYS) {
+            const current = key === "hp"
+                ? Number(this.system.attributes?.hp?.max || 0)
+                : Number(this.system.attributes?.[key]?.value || 0);
+            const nextBase = Number(chosenNode?.baseStats?.[key] || 0);
+            let result = current;
+
+            // Recruit/Standard promotions floor to the target class base.
+            if (fromBaseClass && !promoteToAdvanced) result = Math.max(current, nextBase);
+
+            // Standard->Promoted/Advanced applies explicit promotion stat bonuses.
+            if (promoteToAdvanced) result = current + Math.max(nextBase, 0);
+
+            if (key === "hp") {
+                const diff = result - current;
+                updates["system.attributes.hp.max"] = result;
+                updates["system.attributes.hp.value"] = Math.max(0, Number(this.system.attributes?.hp?.value || 0) + diff);
+            } else {
+                updates[`system.attributes.${key}.value`] = result;
+            }
+        }
+
+        const unitTypes = Object.entries(chosenNode?.unitTypes || {})
+            .filter(([, enabled]) => Boolean(enabled))
+            .map(([name]) => name);
+        updates["system.unitTypes"] = unitTypes;
+
+        const existingRanks = this.system.weaponRanks || {};
+        for (const wt of Object.keys(FEUE.WeaponTypes)) {
+            if (chosenNode?.weaponProficiencies?.[wt] && !existingRanks[wt]) {
+                updates[`system.weaponRanks.${wt}`] = "E";
+            }
+        }
+
+        await this.update(updates);
     }
 
     canUseWeapon(weapon) {
@@ -259,6 +309,28 @@ class FireEmblemCharacterSheet extends ActorSheet {
             data.currentClassType = node.classType;
         }
 
+        const classTypes = data.classes
+            .map(c => this.actor._getCurrentClassNode(c)?.classType)
+            .filter(Boolean);
+        const uniqueClassTypes = [...new Set(classTypes)]
+            .sort((a, b) => (CLASS_TYPE_ORDER[a] ?? -1) - (CLASS_TYPE_ORDER[b] ?? -1));
+        data.classTypes = uniqueClassTypes;
+        data.highestClassType = uniqueClassTypes.length ? uniqueClassTypes[uniqueClassTypes.length - 1] : "—";
+
+        const classProficiencies = (data.equippedClass ? this.actor._getCurrentClassNode(data.equippedClass)?.weaponProficiencies : null) || {};
+        const visibleRankKeys = Object.keys(classProficiencies).filter(k => classProficiencies[k]);
+        const showAllRanks = this._showAllWeaponRanks ?? false;
+        const allRanks = this.actor.system.weaponRanks || {};
+        const buildEntry = (weapon) => ({ weapon, rank: allRanks[weapon] ?? "" });
+        if (showAllRanks || !visibleRankKeys.length) {
+            data.visibleWeaponRanks = Object.keys(allRanks).map(buildEntry);
+            data.hiddenWeaponRanksCount = 0;
+        } else {
+            data.visibleWeaponRanks = visibleRankKeys.map(buildEntry);
+            data.hiddenWeaponRanksCount = Math.max(Object.keys(allRanks).length - visibleRankKeys.length, 0);
+        }
+        data.showAllWeaponRanks = showAllRanks;
+
         // Non-HP attributes for grid
         data.nonHpAttributes = {};
         for (const [key, val] of Object.entries(this.actor.system.attributes || {})) {
@@ -305,6 +377,11 @@ class FireEmblemCharacterSheet extends ActorSheet {
         html.find(".roll-battalion").click(async (ev) => this._onRollBattalion(ev));
         html.find(".roll-spell").click(async (ev) => this._onRollSpell(ev));
         html.find(".roll-combat-art").click(async (ev) => this._onRollCombatArt(ev));
+        html.find(".weapon-ranks-toggle").click(async (ev) => {
+            ev.preventDefault();
+            this._showAllWeaponRanks = !Boolean(this._showAllWeaponRanks);
+            this.render(false);
+        });
     }
 
     async _onRollAttack(event) {
@@ -390,11 +467,13 @@ class FireEmblemCharacterSheet extends ActorSheet {
 
     async _onItemCreate(event) {
         event.preventDefault();
-        const type = event.currentTarget.dataset.type;
-        if (!type) return ui.notifications.error("Missing item type.");
+        const requestedType = event.currentTarget.dataset.type;
+        if (!requestedType) return ui.notifications.error("Missing item type.");
+        const type = requestedType === "miscItem" ? "miscBonus" : requestedType;
         if ((type === "item" || type === "weapon") && this._getInventoryUsage().full) return ui.notifications.error("Inventory full (5 max).");
         if (type === "battalion" && this.actor.items.some(i => i.type === "battalion")) return ui.notifications.error("Only one battalion allowed.");
-        const [created] = await this.actor.createEmbeddedDocuments("Item", [{ name: `New ${type.charAt(0).toUpperCase()}${type.slice(1)}`, type }]);
+        const typeLabel = type === "miscBonus" ? "Misc Item" : `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
+        const [created] = await this.actor.createEmbeddedDocuments("Item", [{ name: `New ${typeLabel}`, type }]);
         if (created) created.sheet.render(true);
     }
 }
@@ -459,28 +538,57 @@ class FireEmblemItemSheet extends ItemSheet {
         const c = html.find("#promotion-tree-container");
         if (!c.length) return;
         const promos = this.item.system.promotions || [];
-        c.html(promos.length ? this._buildTreeHTML(promos, 0, []) : '<p style="color:#8b4513; font-style:italic;">No promotions defined.</p>');
+        const currentPath = this.item.system.currentPath || [];
+        c.html(promos.length ? this._buildTreeHTML(promos, [], currentPath) : '<p style="color:#8b4513; font-style:italic;">No promotions defined.</p>');
     }
 
-    _buildTreeHTML(promos, depth, parentPath) {
-        let html = '';
+    _buildTreeHTML(promos, parentPath, currentPath) {
+        let html = '<ul class="promo-tree-list">';
         for (const p of promos) {
-            const path = [...parentPath, p.id].join(",");
+            const nodePath = [...parentPath, p.id];
+            const path = nodePath.join(",");
             const isProm = ["Promoted", "Advanced"].includes(p.classType);
-            html += `<div style="margin-left:${depth * 24}px; display:flex; align-items:center; gap:8px; padding:4px 8px; margin:3px 0; background:#f9f9f9; border:1px solid #8b7355; border-radius:4px;">
-                <span style="flex:1;"><b>${p.name}</b> <span style="color:${isProm ? "#8b4513" : "#2c4875"}; font-size:11px;">(${p.classType})</span></span>
-                <a class="promo-edit" data-path="${path}" title="Edit" style="cursor:pointer;"><i class="fas fa-edit"></i></a>
-                <a class="promo-delete" data-path="${path}" title="Delete" style="cursor:pointer;color:#a0522d;"><i class="fas fa-trash"></i></a>
-                <a class="promo-add-sub" data-path="${path}" title="Add Sub-Promotion" style="cursor:pointer;color:#2c4875;"><i class="fas fa-plus"></i></a>
-            </div>`;
-            if (p.promotions?.length) html += this._buildTreeHTML(p.promotions, depth + 1, [...parentPath, p.id]);
+            const checked = nodePath.length === currentPath.length && nodePath.every((id, idx) => id === currentPath[idx]);
+            html += `<li class="promo-tree-node${checked ? " is-selected" : ""}">
+                <div class="promo-tree-row">
+                    <span class="promo-tree-label" style="color:${isProm ? "#8b4513" : "#2c4875"};">
+                        <b>${p.name}</b>
+                        <span class="promo-tree-type">(${p.classType})</span>
+                        ${checked ? '<span class="promo-tree-check"><i class="fas fa-check-circle"></i> Active</span>' : ""}
+                    </span>
+                    <a class="promo-edit" data-path="${path}" title="Edit" style="cursor:pointer;"><i class="fas fa-edit"></i></a>
+                    <a class="promo-delete" data-path="${path}" title="Delete" style="cursor:pointer;color:#a0522d;"><i class="fas fa-trash"></i></a>
+                    <a class="promo-add-sub" data-path="${path}" title="Add Sub-Promotion" style="cursor:pointer;color:#2c4875;"><i class="fas fa-plus"></i></a>
+                </div>
+                ${p.promotions?.length ? this._buildTreeHTML(p.promotions, nodePath, currentPath) : ""}
+            </li>`;
         }
+        html += "</ul>";
         return html;
     }
 
     async _addPromotion(parentPath) {
+        const getTypeForPath = (path) => {
+            if (!path.length) return this.item.system.classType || "Standard";
+            let node = {
+                classType: this.item.system.classType,
+                promotions: this.item.system.promotions || []
+            };
+            for (const id of path) {
+                const next = (node.promotions || []).find(p => p.id === id);
+                if (!next) break;
+                node = next;
+            }
+            return node.classType || "Standard";
+        };
+        const parentType = getTypeForPath(parentPath);
+        const nextClassType = parentType === "Recruit"
+            ? "Standard"
+            : parentType === "Standard"
+                ? "Promoted"
+                : "Advanced";
         const newP = {
-            id: foundry.utils.randomID(), name: "New Class", classType: parentPath.length ? "Promoted" : "Standard",
+            id: foundry.utils.randomID(), name: "New Class", classType: nextClassType,
             movement: 5, maxLevel: 20, unitTypes: {}, weaponProficiencies: {}, baseStats: {}, growthRates: {}, statCaps: {}, promotions: []
         };
         this._openPromotionDialog(newP, async (data) => {
@@ -525,6 +633,10 @@ class FireEmblemItemSheet extends ItemSheet {
         const isProm = ["Promoted", "Advanced"].includes(promo.classType);
         const bs = promo.baseStats || {}, gr = promo.growthRates || {}, sc = promo.statCaps || {};
         const sr = (pfx, obj) => FEUE.STAT_KEYS.map(k => `<div style="display:inline-block;width:18%;margin:2px;"><label style="font-size:11px;">${FEUE.STAT_LABELS[k]}</label><input type="number" data-key="${pfx}.${k}" value="${obj[k] || 0}" style="width:100%;"/></div>`).join("");
+        const unitTypes = promo.unitTypes || {};
+        const weaponProficiencies = promo.weaponProficiencies || {};
+        const unitTypeChecks = FEUE.UNIT_TYPES.map(type => `<label style="display:inline-flex;align-items:center;gap:4px;margin-right:10px;"><input type="checkbox" data-key="ut.${type}" ${unitTypes[type] ? "checked" : ""}/> ${type}</label>`).join("");
+        const weaponChecks = Object.entries(FEUE.WeaponTypes).map(([key, label]) => `<label style="display:inline-flex;align-items:center;gap:4px;margin-right:10px;"><input type="checkbox" data-key="wp.${key}" ${weaponProficiencies[key] ? "checked" : ""}/> ${label}</label>`).join("");
 
         new Dialog({
             title: `Edit: ${promo.name}`,
@@ -532,7 +644,9 @@ class FireEmblemItemSheet extends ItemSheet {
                 <div class="form-group"><label>Name</label><input type="text" id="pn" value="${promo.name}"/></div>
                 <div class="form-group"><label>Class Type</label><select id="pct">${FEUE.CLASS_TYPES.map(t => `<option value="${t}" ${promo.classType === t ? "selected" : ""}>${t}</option>`).join("")}</select></div>
                 <div style="display:flex;gap:8px;"><div class="form-group" style="flex:1;"><label>Max Level</label><input type="number" id="pml" value="${promo.maxLevel || 20}"/></div><div class="form-group" style="flex:1;"><label>Movement</label><input type="number" id="pmv" value="${promo.movement || 5}"/></div></div>
-                <hr/><div id="pbs" ${isProm ? 'style="display:none;"' : ''}><h4>Base Stats</h4><div>${sr("bs", bs)}</div><hr/></div>
+                <hr/><h4>Unit Types</h4><div>${unitTypeChecks}</div>
+                <hr/><h4>Weapon Proficiencies</h4><div>${weaponChecks}</div>
+                <hr/><div id="pbs"><h4>${isProm ? "Stat Bonuses" : "Base Stats"}</h4><div>${sr("bs", bs)}</div><hr/></div>
                 <h4>Growth Rates</h4><div>${sr("gr", gr)}</div><hr/>
                 <h4>Stat Caps</h4><div>${sr("sc", sc)}</div></form>`,
             buttons: {
@@ -540,14 +654,16 @@ class FireEmblemItemSheet extends ItemSheet {
                     icon: '<i class="fas fa-save"></i>', label: "Save", callback: (h) => {
                         const d = {
                             id: promo.id, name: h.find("#pn").val() || "Unnamed", classType: h.find("#pct").val(), maxLevel: Number(h.find("#pml").val()) || 20, movement: Number(h.find("#pmv").val()) || 5,
-                            unitTypes: promo.unitTypes || {}, weaponProficiencies: promo.weaponProficiencies || {}, baseStats: {}, growthRates: {}, statCaps: {}, promotions: promo.promotions || []
+                            unitTypes: {}, weaponProficiencies: {}, baseStats: {}, growthRates: {}, statCaps: {}, promotions: promo.promotions || []
                         };
-                        h.find("input[data-key]").each((_, el) => { const [g, s] = el.dataset.key.split("."); const map = { bs: "baseStats", gr: "growthRates", sc: "statCaps" }; d[map[g]][s] = Number(el.value) || 0; });
+                        h.find("input[type='number'][data-key]").each((_, el) => { const [g, s] = el.dataset.key.split("."); const map = { bs: "baseStats", gr: "growthRates", sc: "statCaps" }; d[map[g]][s] = Number(el.value) || 0; });
+                        h.find("input[type='checkbox'][data-key^='ut.']").each((_, el) => { const key = el.dataset.key.slice(3); d.unitTypes[key] = el.checked; });
+                        h.find("input[type='checkbox'][data-key^='wp.']").each((_, el) => { const key = el.dataset.key.slice(3); d.weaponProficiencies[key] = el.checked; });
                         onSave(d);
                     }
                 }, cancel: { label: "Cancel" }
             }, default: "save",
-            render: (h) => { h.find("#pct").change(e => { h.find("#pbs").toggle(!["Promoted", "Advanced"].includes(e.currentTarget.value)); }); }
+            render: (h) => { h.find("#pct").change(e => { h.find("#pbs h4").text(["Promoted", "Advanced"].includes(e.currentTarget.value) ? "Stat Bonuses" : "Base Stats"); }); }
         }, { width: 500 }).render(true);
     }
 }

--- a/styles/feue.css
+++ b/styles/feue.css
@@ -248,6 +248,50 @@
     background: white;
 }
 
+/* ===== PROMOTION TREE ===== */
+.promo-tree-list {
+    list-style: none;
+    margin: 0 0 0 14px;
+    padding: 0 0 0 12px;
+    border-left: 1px solid rgba(44, 72, 117, 0.35);
+}
+
+.promo-tree-node {
+    margin: 6px 0;
+}
+
+.promo-tree-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border: 1px solid var(--feue-border);
+    border-radius: 4px;
+    background: #f9f9f9;
+}
+
+.promo-tree-label {
+    flex: 1;
+}
+
+.promo-tree-type {
+    font-size: 11px;
+}
+
+.promo-tree-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+    font-size: 11px;
+    color: #1f6b2c;
+}
+
+.promo-tree-node.is-selected .promo-tree-row {
+    background: #edf8ef;
+    border-color: #2e7d32;
+}
+
 /* ===== COMBAT STATS ===== */
 .feue .combat-stats {
     background: white;

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -85,14 +85,22 @@
 
             {{!-- Weapon Ranks --}}
             <div class="weapon-ranks">
-                <h3>Weapon Ranks</h3>
+                <div class="section-header">
+                    <h3>Weapon Ranks</h3>
+                    {{#if hiddenWeaponRanksCount}}
+                    <a class="item-control weapon-ranks-toggle" title="Toggle all weapon ranks">
+                        <i class="fas {{#if showAllWeaponRanks}}fa-eye-slash{{else}}fa-eye{{/if}}"></i>
+                        {{#if showAllWeaponRanks}}Show Class Only{{else}}Show All ({{hiddenWeaponRanksCount}} hidden){{/if}}
+                    </a>
+                    {{/if}}
+                </div>
                 <div class="weapon-ranks-grid">
-                    {{#each actor.system.weaponRanks as |rank weapon|}}
+                    {{#each visibleWeaponRanks as |entry|}}
                     <div class="weapon-rank flexrow">
-                        <label class="weapon-label">{{weapon}}</label>
-                        <select name="system.weaponRanks.{{weapon}}" data-weapon-type="{{weapon}}">
+                        <label class="weapon-label">{{entry.weapon}}</label>
+                        <select name="system.weaponRanks.{{entry.weapon}}" data-weapon-type="{{entry.weapon}}">
                             {{#each ../weaponRankOptions as |opt|}}
-                            <option value="{{opt.key}}" {{#ifEquals rank opt.key}} selected{{/ifEquals}}>{{opt.label}}</option>
+                            <option value="{{opt.key}}" {{#ifEquals ../entry.rank opt.key}} selected{{/ifEquals}}>{{opt.label}}</option>
                             {{/each}}
                         </select>
                     </div>
@@ -126,6 +134,10 @@
                     <div class="resource flexrow">
                         <label>Experience</label>
                         <input type="text" name="system.experience" value="{{actor.system.experience}}" data-dtype="Number" />
+                    </div>
+                    <div class="resource flexrow">
+                        <label>Class Type(s)</label>
+                        <input type="text" value="{{highestClassType}}{{#if classTypes.length}} ({{join classTypes ", "}}){{/if}}" disabled />
                     </div>
                 </div>
             </div>
@@ -273,7 +285,7 @@
             </div>
 
             <div class="spells-section">
-                <div class="section-header"><h3>Misc Bonuses</h3><a class="item-control item-create" data-type="miscBonus" title="Create Misc Bonus"><i class="fas fa-plus"></i> Add Bonus</a></div>
+                <div class="section-header"><h3>Misc Items</h3><a class="item-control item-create" data-type="miscItem" title="Create Misc Item"><i class="fas fa-plus"></i> Add Misc Item</a></div>
                 {{#each miscBonuses as |bonus|}}
                 <div class="item bonus flexrow" data-item-id="{{bonus._id}}">
                     <div class="item-image"><img src="{{bonus.img}}" title="{{bonus.name}}" width="24" height="24" /></div>

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -15,7 +15,6 @@
         {{#if (eq item.type "combatArt")}}<a class="item" data-tab="combatArt">Combat Art</a>{{/if}}
         {{#if (eq item.type "battalion")}}<a class="item" data-tab="battalion">Battalion</a>{{/if}}
         {{#if (eq item.type "class")}}<a class="item" data-tab="class">Class</a>{{/if}}
-        {{#if (eq item.type "miscBonus")}}<a class="item" data-tab="miscBonus">Misc Bonus</a>{{/if}}
     </nav>
 
     <section class="sheet-body">
@@ -155,7 +154,7 @@
         {{#if (eq item.type "class")}}
         <div class="tab class" data-group="primary" data-tab="class">
             <div class="form-row">
-                <div class="form-group"><label>Class Type</label><select name="system.classType"><option value="Recruit" {{#ifEquals item.system.classType "Recruit"}} selected{{/ifEquals}}>Recruit</option><option value="Standard" {{#ifEquals item.system.classType "Standard"}} selected{{/ifEquals}}>Standard</option><option value="Promoted" {{#ifEquals item.system.classType "Promoted"}} selected{{/ifEquals}}>Promoted</option><option value="Advanced" {{#ifEquals item.system.classType "Advanced"}} selected{{/ifEquals}}>Advanced</option><option value="Enemy Only" {{#ifEquals item.system.classType "Enemy Only"}} selected{{/ifEquals}}>Enemy Only</option></select></div>
+                <div class="form-group"><label>Class Type</label><select name="system.classType"><option value="Recruit" {{#ifEquals item.system.classType "Recruit"}} selected{{/ifEquals}}>Recruit</option><option value="Standard" {{#ifEquals item.system.classType "Standard"}} selected{{/ifEquals}}>Standard</option><option value="Advanced" {{#ifEquals item.system.classType "Advanced"}} selected{{/ifEquals}}>Advanced</option><option value="Enemy Only" {{#ifEquals item.system.classType "Enemy Only"}} selected{{/ifEquals}}>Enemy Only</option></select></div>
                 <div class="form-group"><label>Max Level</label><input type="number" data-dtype="Number" name="system.maxLevel" value="{{item.system.maxLevel}}" /></div>
                 <div class="form-group"><label>Movement</label><input type="number" data-dtype="Number" name="system.movement" value="{{item.system.movement}}" /></div>
             </div>
@@ -233,12 +232,6 @@
                 </div>
                 <div id="promotion-tree-container"></div>
             </div>
-        </div>
-        {{/if}}
-
-        {{#if (eq item.type "miscBonus")}}
-        <div class="tab miscBonus" data-group="primary" data-tab="miscBonus">
-            <p>Use the Description tab to configure all misc bonus values.</p>
         </div>
         {{/if}}
 


### PR DESCRIPTION
### Motivation

- Persist class `unitTypes` and `weaponProficiencies` and ensure promotions update actor stats and proficiencies when a promotion is chosen. 
- Provide clearer UX for editing and visualizing promotion trees including highlighting the active promotion path. 
- Allow users to toggle visibility of weapon ranks on the character sheet and simplify misc item creation.

### Description

- Add `CLASS_TYPE_ORDER` and include `unitTypes` and `weaponProficiencies` when resolving class nodes via `_getCurrentClassNode` to preserve class capability metadata. 
- Implement `_applyPromotionBenefits(previousNode, chosenNode)` and invoke it from the promotion flow in `_showPromotionDialog` to apply HP, attribute, unit type, and weapon proficiency changes (including granting an `E` rank where appropriate). 
- Surface class type summary and a weapon-rank visibility feature in `getData()` and templates with a toggle handler in `activateListeners`, plus map the UI `miscItem` create action to the internal `miscBonus` item type and label created items as `Misc Item`. 
- Replace the promotion tree renderer with a nested list view that highlights the active node and wire the promotion editor to handle `unitTypes` and `weaponProficiencies` via checkbox inputs, updating saved promotion nodes accordingly. 
- Add CSS rules for the promotion tree styling and update templates to show only the selected weapon-rank subset by default with a toggle to show all ranks, and update the class/item sheet markup to match the new behavior.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f47726988320b3b18b32aee28308)