### PR TITLE
Rewrite CSS for readability and enhanced Fire Emblem aesthetic

### DIFF
--- a/styles/feue.css
+++ b/styles/feue.css
@@ -1,8 +1,8 @@
 /* ========================================
-   Fire Emblem: Ultimate Edition CSS
+   Fire Emblem: Ultimate Edition
    ======================================== */
 
-/* ===== FONTS & VARIABLES ===== */
+/* ===== FONTS ===== */
 @font-face {
     font-family: "NocturneSerif-Regular";
     src: url("../fonts/NocturneSerif-Regular.otf") format("opentype");
@@ -24,26 +24,51 @@
     font-style: normal;
 }
 
+/* ===== CUSTOM PROPERTIES ===== */
 :root {
-    --feue-primary: #2c2a4a;      /* Muted indigo */
-    --feue-secondary: #d4af37;    /* Regal gold */
-    --feue-accent: #7a1f2b;       /* Noble burgundy */
-    --feue-bg: #f8f1e1;           /* Refined parchment */
-    --feue-text: #222222;         /* Soft black */
-    --feue-border: #c2a96a;       /* Elegant gold trim */
-    --feue-header-bg: #1b1a33;    /* Dark academic navy */
-    --feue-tab-active: #3f3c77;   /* Royal indigo */
+    --feue-primary: #2c2a4a;
+    --feue-secondary: #d4af37;
+    --feue-accent: #7a1f2b;
+    --feue-bg: #f8f1e1;
+    --feue-text: #222222;
+    --feue-border: #c2a96a;
+    --feue-header-bg: #1b1a33;
+    --feue-tab-active: #3f3c77;
+    --feue-card-bg: #fdf8ef;
+    --feue-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.08),
+                        inset 0 1px 0 rgba(255, 255, 255, 0.6);
 
-    /* Font Variables */
     --feue-font-body: "NocturneSerif-Regular", "Times New Roman", serif;
     --feue-font-header: "ChiaroStd-Bold", "Georgia", serif;
     --feue-font-gba: "FE8Text", monospace;
 }
 
+/* ===== BASE ===== */
 .feue {
     font-family: var(--feue-font-body);
     background: var(--feue-bg);
     color: var(--feue-text);
+}
+
+.feue h1,
+.feue h2,
+.feue h3,
+.feue h4,
+.feue .section-header h3,
+.feue .charname input {
+    font-family: var(--feue-font-header);
+    letter-spacing: 0.5px;
+}
+
+.feue h3 {
+    font-size: 14px;
+    color: var(--feue-primary);
+    font-weight: bold;
+    margin: 0 0 10px 0;
+}
+
+.feue h4 {
+    font-size: 13px;
 }
 
 .window-app.feue .window-content,
@@ -52,82 +77,153 @@
     padding: 0;
 }
 
-    .window-app.feue .window-content > form,
-    .app.feue .window-content > form {
-        background: transparent;
-        padding: 0;
-    }
+.window-app.feue .window-content > form,
+.app.feue .window-content > form {
+    background: transparent;
+    padding: 0;
+}
 
-/* ===== HEADER STYLES (FIXED) ===== */
+/* ===== SHEET HEADER ===== */
 .feue .sheet-header {
     background: linear-gradient(135deg, var(--feue-header-bg) 0%, var(--feue-primary) 100%);
     color: white;
-    padding: 12px 16px; /* Increased padding */
-    border-bottom: 2px solid var(--feue-accent);
-    min-height: 100px; /* Increased height constraint */
-    max-height: 175px; /* Prevent expansion */
-    overflow: hidden; /* Hide any overflow */
+    padding: 12px 16px;
+    border-bottom: 3px solid var(--feue-accent);
+    min-height: 100px;
+    max-height: 175px;
+    overflow: hidden;
+    font-family: var(--feue-font-header);
 }
 
-    .feue .sheet-header.flexrow {
-        align-items: center;
-        gap: 16px;
-    }
+.feue .sheet-header.flexrow {
+    align-items: center;
+    gap: 16px;
+}
 
 .feue .profile-img {
-    border: 3px solid var(--feue-accent); /* Back to original border */
-    border-radius: 8px;
+    border: 3px solid var(--feue-secondary);
+    border-radius: 6px;
     object-fit: cover;
-    width: 80px; /* Larger image */
-    height: 80px; /* Larger image */
-    flex-shrink: 0; /* Prevent shrinking */
+    width: 80px;
+    height: 80px;
+    flex-shrink: 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
-/* Header fields container */
 .feue .header-fields {
     flex: 1;
-    min-height: 0; /* Allow shrinking */
+    min-height: 0;
     overflow: hidden;
 }
 
 .feue .charname {
-    margin: 0 0 6px 0; /* Slightly more margin */
+    margin: 0 0 4px 0;
 }
 
-    .feue .charname input {
-        background: transparent;
-        border: none;
-        color: white;
-        font-size: 18px; /* Back to larger font */
-        font-weight: bold;
-        text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
-        padding: 0;
-        margin: 0;
-    }
+.feue .charname input {
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 22px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.6);
+    padding: 0;
+    margin: 0;
+}
+
+.feue .header-row {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
 
 .feue .resource {
-    margin: 4px 0; /* More margin */
+    margin: 3px 0;
     align-items: center;
     min-height: 0;
 }
 
 .feue .resource-label {
     font-weight: bold;
-    min-width: 60px;
-    color: antiquewhite;
-    font-size: 18px;
-    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+    min-width: 55px;
+    color: var(--feue-secondary);
+    font-size: 14px;
+    font-family: var(--feue-font-gba);
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.5);
+    letter-spacing: 0.5px;
+}
+
+.feue .resource-value {
+    color: rgba(255, 255, 255, 0.9);
+    font-family: var(--feue-font-gba);
+    font-size: 13px;
 }
 
 .feue .resource-value input,
 .feue .resource-value select {
-    background: rgba(255,255,255,0.1);
-    border: 1px solid rgba(255,255,255,0.3);
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.25);
     color: white;
-    padding: 2px 4px;
+    padding: 2px 6px;
     border-radius: 3px;
-    width: 120px;
+    width: 50px;
     font-size: 13px;
+    font-family: var(--feue-font-gba);
+    text-align: center;
+}
+
+.feue .resource-value input:disabled {
+    opacity: 1;
+}
+
+/* HP display */
+.feue .hp-fields {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.feue .hp-fields .hp-current {
+    width: 50px;
+    font-size: 15px;
+    font-family: var(--feue-font-gba);
+    color: #90ee90;
+    text-align: center;
+}
+
+.feue .hp-fields span {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.feue .hp-fields .hp-max {
+    font-family: var(--feue-font-gba);
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* Level Up button */
+.feue .level-up {
+    background: linear-gradient(180deg, #9b2335, var(--feue-accent));
+    color: white;
+    border: 1px solid #5a1520;
+    border-radius: 4px;
+    padding: 5px 14px;
+    font-weight: bold;
+    font-family: var(--feue-font-gba);
+    font-size: 11px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    cursor: pointer;
+    margin-left: 8px;
+    transition: all 0.2s ease;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
+}
+
+.feue .level-up:hover {
+    background: linear-gradient(180deg, #b82a3f, #9b2335);
+    border-color: #7a1f2b;
 }
 
 /* ===== TABS ===== */
@@ -135,40 +231,45 @@
     background: var(--feue-primary);
     border: none;
     border-bottom: 2px solid var(--feue-accent);
-    padding: 0 16px;
-    min-height: 40px;
-    max-height: 40px;
+    padding: 0 8px;
+    min-height: 36px;
+    max-height: 36px;
+    display: flex;
+    align-items: stretch;
+}
+
+.feue .tabs .item {
+    background: transparent;
+    color: rgba(255, 255, 255, 0.7);
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 6px 12px;
+    font-family: var(--feue-font-gba);
+    font-weight: normal;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    line-height: 1.4;
+    transition: all 0.15s ease;
     display: flex;
     align-items: center;
 }
 
-    .feue .tabs .item {
-        background: transparent;
-        color: white;
-        border: none;
-        padding: 8px 12px;
-        font-weight: normal;
-        font-size: 28px;
-        transition: all 0.2s ease;
-        line-height: 0.5;
-        text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
-    }
+.feue .tabs .item:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: white;
+}
 
-        .feue .tabs .item:hover {
-            background: rgba(255,255,255,0.1);
-            color: white;
-        }
-
-        .feue .tabs .item.active {
-            background: var(--feue-tab-active);
-            color: white;
-            border-bottom: 2px solid var(--feue-accent);
-        }
+.feue .tabs .item.active {
+    background: var(--feue-tab-active);
+    color: white;
+    border-bottom-color: var(--feue-secondary);
+}
 
 /* ===== SHEET BODY ===== */
 .feue .sheet-body {
     background: var(--feue-bg);
-    padding: 16px;
+    padding: 12px;
     overflow-y: auto;
 }
 
@@ -176,39 +277,76 @@
     display: none;
 }
 
-    .feue .tab.active {
-        display: block;
-    }
-
-/* ===== ATTRIBUTES & GROWTH RATES ===== */
-.feue .attributes,
-.feue .growth-rates {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin-right: 15px;
-    flex: 1;
+.feue .tab.active {
+    display: block;
 }
 
-    .feue .attributes h3,
-    .feue .growth-rates h3,
-    .feue .weapon-ranks h3,
-    .feue .personal-details h3 {
-        text-align: center;
-    }
+/* ===== SHARED CARD STYLE ===== */
+.feue .attributes,
+.feue .growth-rates,
+.feue .weapon-ranks,
+.feue .combat-stats,
+.feue .weapons-section,
+.feue .items-section,
+.feue .classes-section,
+.feue .skills-section,
+.feue .spells-section,
+.feue .combat-arts-section,
+.feue .battalion-section,
+.feue .inventory-limit,
+.feue .personal-details,
+.feue .biography-text,
+.feue .appearance-text,
+.feue .movement,
+.feue .details {
+    background: var(--feue-card-bg);
+    border: 2px solid var(--feue-border);
+    border-radius: 6px;
+    padding: 12px;
+    box-shadow: var(--feue-card-shadow);
+}
+
+/* ===== MAIN TAB: ATTRIBUTES ===== */
+.feue .attributes,
+.feue .growth-rates {
+    flex: 1;
+    margin-bottom: 12px;
+}
+
+.feue .attributes {
+    margin-right: 12px;
+}
+
+.feue .attributes h3,
+.feue .growth-rates h3 {
+    text-align: center;
+    border-bottom: 2px solid var(--feue-accent);
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+}
 
 .feue .attributes-grid,
-.feue .growth-grid {
+.feue .growth-rates-grid {
     display: grid;
-    gap: 8px;
+    gap: 0;
 }
 
 .feue .attribute,
 .feue .growth-rate {
+    display: flex;
     align-items: center;
-    padding: 5px 0;
-    border-bottom: 1px solid rgba(139,115,85,0.3);
+    padding: 4px 6px;
+    border-bottom: 1px solid rgba(139, 115, 85, 0.15);
+}
+
+.feue .attribute:nth-child(even),
+.feue .growth-rate:nth-child(even) {
+    background: rgba(139, 115, 85, 0.06);
+}
+
+.feue .attribute:last-child,
+.feue .growth-rate:last-child {
+    border-bottom: none;
 }
 
 .feue .attribute-label,
@@ -217,752 +355,87 @@
     text-transform: capitalize;
     min-width: 80px;
     color: var(--feue-secondary);
+    font-size: 12px;
 }
 
 .feue .attribute-value {
     display: flex;
     align-items: center;
-    gap: 5px;
+    gap: 4px;
+    margin-left: auto;
 }
 
-    .feue .attribute-value input,
-    .feue .growth-rate input {
-        width: 40px;
-        text-align: center;
-        border: 1px solid var(--feue-border);
-        border-radius: 3px;
-        padding: 2px;
-    }
+.feue .attribute-value span {
+    color: var(--feue-secondary);
+    font-size: 11px;
+}
 
-/* ===== WEAPON RANKS ===== */
-.feue .weapon-ranks {
+.feue .attribute-value input,
+.feue .growth-rate input {
+    width: 38px;
+    text-align: center;
+    border: 1px solid var(--feue-border);
+    border-radius: 3px;
+    padding: 2px;
+    font-family: var(--feue-font-gba);
+    font-size: 13px;
     background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin: 15px 0;
+    color: var(--feue-primary);
+}
+
+.feue .attribute-value input:disabled,
+.feue .growth-rate input:disabled {
+    background: transparent;
+    border-color: rgba(194, 169, 106, 0.3);
+    color: var(--feue-primary);
+}
+
+/* ===== MAIN TAB: WEAPON RANKS ===== */
+.feue .weapon-ranks {
+    margin: 12px 0;
+}
+
+.feue .weapon-ranks h3 {
+    text-align: center;
+    border-bottom: 2px solid var(--feue-accent);
+    padding-bottom: 6px;
+    margin-bottom: 10px;
 }
 
 .feue .weapon-ranks-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 8px;
 }
 
 .feue .weapon-rank {
+    display: flex;
     align-items: center;
     gap: 8px;
+    padding: 3px 6px;
+    border-radius: 4px;
+}
+
+.feue .weapon-rank.proficient {
+    background: rgba(46, 125, 50, 0.08);
+    border: 1px solid rgba(46, 125, 50, 0.2);
 }
 
 .feue .weapon-label {
     text-transform: capitalize;
     font-weight: bold;
     color: var(--feue-secondary);
-    min-width: 70px;
+    min-width: 60px;
+    font-size: 12px;
 }
 
 .feue .weapon-rank select {
     border: 1px solid var(--feue-border);
     border-radius: 3px;
-    padding: 2px;
+    padding: 2px 4px;
     background: white;
-}
-
-/* ===== PROMOTION TREE ===== */
-.promo-tree-list {
-    list-style: none;
-    margin: 0 0 0 14px;
-    padding: 0 0 0 12px;
-    border-left: 1px solid rgba(44, 72, 117, 0.35);
-}
-
-.promo-tree-node {
-    margin: 6px 0;
-}
-
-.promo-tree-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 5px 8px;
-    border: 1px solid var(--feue-border);
-    border-radius: 4px;
-    background: #f9f9f9;
-}
-
-.promo-tree-label {
-    flex: 1;
-}
-
-.promo-tree-type {
-    font-size: 11px;
-}
-
-.promo-tree-check {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    margin-left: 8px;
-    font-size: 11px;
-    color: #1f6b2c;
-}
-
-.promo-tree-node.is-selected .promo-tree-row {
-    background: #edf8ef;
-    border-color: #2e7d32;
-}
-
-/* ===== COMBAT STATS ===== */
-.feue .combat-stats {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 15px;
-    justify-content: space-around;
-}
-
-.feue .combat-stat {
-    text-align: center;
-    padding: 10px;
-    border-radius: 6px;
-    background: linear-gradient(135deg, #f0f0f0 0%, #e0e0e0 100%);
-    min-width: 100px;
-}
-
-    .feue .combat-stat label {
-        display: block;
-        font-weight: bold;
-        color: var(--feue-secondary);
-        margin-bottom: 5px;
-    }
-
-.feue .computed-value {
-    font-size: 18px;
-    font-weight: bold;
-    color: var(--feue-primary);
-}
-
-/* ===== WEAPONS & ITEMS ===== */
-.feue .weapons-section,
-.feue .items-section,
-.feue .classes-section,
-.feue .skills-section,
-.feue .spells-section,
-.feue .battalion-section,
-.feue .inventory-limit {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin: 15px 0;
-}
-
-.feue .section-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 8px;
-    border-bottom: 1px solid rgba(139,115,85,0.35);
-    padding-bottom: 4px;
-}
-
-.feue .section-header h3 {
-    margin: 0;
-}
-
-.feue .item-create {
-    display: inline-flex;
-    gap: 6px;
-    align-items: center;
-    border: 1px solid var(--feue-primary);
-    border-radius: 4px;
-    padding: 2px 8px;
     font-size: 12px;
-    color: white;
-    background: linear-gradient(180deg, var(--feue-tab-active), var(--feue-primary));
-}
-
-.feue .item-create:hover {
-    text-shadow: none;
-    background: linear-gradient(180deg, #5e83b6, #2f5485);
-}
-
-.feue .item-create.disabled {
-    opacity: 0.6;
-}
-
-.feue .limit-note,
-.feue .empty-note,
-.feue .inventory-limit p {
-    color: var(--feue-secondary);
-    font-style: italic;
-    margin: 0;
-}
-
-.feue .item {
-    background: #f9f9f9;
-    border: 1px solid var(--feue-border);
-    border-radius: 6px;
-    padding: 8px;
-    margin: 5px 0;
-    align-items: center;
-    transition: background-color 0.2s ease;
-}
-
-    .feue .item:hover {
-        background: #f0f0f0;
-    }
-
-.feue .item-image img {
-    border: 1px solid var(--feue-border);
-    border-radius: 3px;
-}
-
-.feue .item-name {
     flex: 1;
-    margin: 0 10px;
-    font-weight: bold;
-    color: var(--feue-text);
-}
-
-.feue .weapon-stats {
-    display: flex;
-    gap: 1.5px;
-    margin-right: 10px;
-    flex-wrap: wrap;
-}
-
-    .feue .weapon-stats span {
-        background: var(--feue-tab-active);
-        color: white;
-        padding: 2px 6px;
-        border-radius: 12px;
-        font-size: 20px;
-        font-weight: 50;
-        line-height: 1.2;
-    }
-
-.feue .item-controls {
-    display: flex;
-    gap: 1px;
-}
-
-.feue .item-control {
-    background: var(--feue-secondary);
-    color: white;
-    border: none;
-    border-radius: 3px;
-    padding: 4px 6px;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
-}
-
-    .feue .item-control:hover {
-        background: #a0522d;
-    }
-
-.feue .item-equip.equipped {
-    background: var(--feue-accent);
-}
-
-/* ===== SKILLS & SPELLS ===== */
-.feue .classes-section,
-.feue .skills-section,
-.feue .spells-section {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    flex: 1;
-    margin-bottom: 15px;
-    gap: 8px;
-}
-
-.feue .classes-section {
-    margin-right: 15px;
-}
-
-.feue .skills-section {
-    margin-right: 15px;
-}
-
-.feue .class-info,
-.feue .skill-info,
-.feue .spell-info {
-    flex: 1;
-    margin: 0 10px;
-}
-
-.feue .class-details,
-.feue .skill-type,
-.feue .spell-details {
-    margin: 0;
-    font-size: 12px;
-    color: var(--feue-secondary);
-    font-style: italic;
-}
-
-/* ===== ITEM SHEETS ===== */
-.feue .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 10px;
-    margin: 10px 0;
-}
-
-.feue .form-row {
-    display: flex;
-    gap: 15px;
-    margin: 10px 0;
-}
-
-.feue .form-group {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    gap: 5px;
-}
-
-    .feue .form-group label {
-        font-weight: bold;
-        color: var(--feue-secondary);
-        font-size: 12px;
-    }
-
-    .feue .form-group input,
-    .feue .form-group select,
-    .feue .form-group textarea {
-        border: 1px solid var(--feue-border);
-        border-radius: 3px;
-        padding: 4px 6px;
-        font-size: 12px;
-    }
-
-.feue .uses-group {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-}
-
-    .feue .uses-group input {
-        width: 50px;
-        text-align: center;
-    }
-
-    .feue .uses-group span {
-        font-weight: bold;
-        color: var(--feue-secondary);
-    }
-
-/* ===== BIOGRAPHY ===== */
-.feue .personal-details {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 15px;
-}
-
-.feue .details-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 10px;
-}
-
-.feue .detail {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-}
-
-    .feue .detail label {
-        font-weight: bold;
-        color: var(--feue-secondary);
-    }
-
-    .feue .detail input {
-        border: 1px solid var(--feue-border);
-        border-radius: 3px;
-        padding: 4px;
-    }
-
-.feue .biography-text,
-.feue .appearance-text {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 15px;
-}
-
-    .feue .biography-text textarea,
-    .feue .appearance-text textarea {
-        width: 100%;
-        border: 1px solid var(--feue-border);
-        border-radius: 4px;
-        padding: 8px;
-        font-family: inherit;
-        resize: vertical;
-    }
-
-/* ===== BUTTONS ===== */
-.feue .level-up {
-    background: var(--feue-accent);
-    color: white;
-    border: none;
-    border-radius: 4px;
-    padding: 8px 16px; /* Increased padding */
-    font-weight: bold;
-    cursor: pointer;
-    margin-left: 10px;
-    transition: background-color 0.2s ease;
-    font-size: 13px; /* Slightly larger font */
-}
-
-    .feue .level-up:hover {
-        background: #b8860b;
-    }
-
-/* ===== LEVEL UP CHAT MESSAGE ===== */
-.feue-levelup {
-    background: linear-gradient(135deg, var(--feue-primary) 0%, var(--feue-accent) 100%);
-    color: white;
-    padding: 15px;
-    border-radius: 8px;
-    margin: 5px 0;
-    text-align: center;
-}
-
-    .feue-levelup h3 {
-        margin: 0 0 10px 0;
-        font-size: 16px;
-    }
-
-    .feue-levelup .stat-gains {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 8px;
-        margin-top: 10px;
-    }
-
-    .feue-levelup .gain {
-        background: rgba(255,255,255,0.2);
-        padding: 4px 8px;
-        border-radius: 4px;
-        font-weight: bold;
-        font-size: 12px;
-    }
-
-/* ===== ATTACK ROLL CHAT MESSAGE ===== */
-.feue-attack-roll {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin: 5px 0;
-}
-
-    .feue-attack-roll h3 {
-        color: var(--feue-primary);
-        margin: 0 0 10px 0;
-        font-size: 14px;
-    }
-
-    .feue-attack-roll p {
-        margin: 5px 0;
-    }
-
-/* ===== RESPONSIVE DESIGN ===== */
-@media (max-width: 800px) {
-    .feue .sheet-header {
-        flex-direction: column;
-        text-align: center;
-    }
-
-    .feue .flexrow {
-        flex-direction: column;
-    }
-
-    .feue .attributes,
-    .feue .growth-rates,
-    .feue .skills-section {
-        margin-right: 0;
-        margin-bottom: 15px;
-    }
-
-    .feue .combat-stats {
-        flex-direction: column;
-        gap: 10px;
-    }
-
-    .feue .weapon-ranks-grid,
-    .feue .details-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-/* ===== UTILITY CLASSES ===== */
-.feue .flexrow {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-}
-
-.feue .flexcol {
-    display: flex;
-    flex-direction: column;
-}
-
-.feue .flex {
-    flex: 1;
-}
-
-.feue .text-center {
-    text-align: center;
-}
-
-.feue h1,
-.feue h2,
-.feue h3,
-.feue h4,
-.feue .section-header h3,
-.feue .charname input,
-.feue .sheet-header {
-    font-family: var(--feue-font-header);
-    letter-spacing: 0.5px;
-}
-
-.feue .charname input {
-    font-size: 22px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
-/* Reduce all header sizes */
-.feue h3 {
-    font-size: 14px;
-}
-
-.feue h4 {
-    font-size: 13px;
-}
-
-.feue .weapon-ranks h3,
-.feue .combat-stats h3,
-.feue .weapons-section h3,
-.feue .items-section h3,
-.feue .skills-section h3,
-.feue .spells-section h3,
-.feue .personal-details h3,
-.feue .biography-text h3,
-.feue .appearance-text h3 {
-    color: var(--feue-primary);
-    font-weight: bold;
-    margin: 0 0 10px 0;
-    font-size: 14px;
-}
-
-.feue .weapon-ranks h3,
-.feue .personal-details h3 {
-    text-align: center;
-}
-
-.feue .weapons-section h3,
-.feue .items-section h3,
-.feue .skills-section h3,
-.feue .spells-section h3 {
-    border-bottom: 2px solid var(--feue-accent);
-    padding-bottom: 5px;
-}
-
-/* ===== ITEM SHEET SPECIFIC FIXES ===== */
-.feue.item .sheet-header {
-    padding: 8px 12px; /* Increased padding */
-    min-height: 70px; /* Increased height */
-    max-height: 70px; /* Prevent expansion */
-}
-
-    .feue.item .sheet-header .item-img {
-        width: 52px; /* Larger item image */
-        height: 52px;
-        border: 2px solid var(--feue-accent);
-        border-radius: 4px;
-        flex-shrink: 0;
-    }
-
-    .feue.item .sheet-header .header-fields {
-        flex: 1;
-        margin-left: 12px;
-        min-height: 0;
-    }
-
-    .feue.item .sheet-header .item-name {
-        margin: 0;
-        font-size: 16px; /* Larger font */
-    }
-
-        .feue.item .sheet-header .item-name input {
-            background: transparent;
-            border: none;
-            color: white;
-            font-size: 16px;
-            font-weight: bold;
-            width: 100%;
-            padding: 0;
-            margin: 0;
-        }
-
-        .feue .class-type
-        {
-            flex: 1;
-            margin: 0 10px;
-            color: var(--feue-text);
-        }
-
-/* ===== COMPACT FORM STYLING ===== */
-.feue.item .form-row {
-    gap: 10px;
-    margin: 8px 0;
-}
-
-.feue.item .form-group {
-    gap: 3px;
-}
-
-    .feue.item .form-group label {
-        font-size: 11px;
-        font-weight: bold;
-        color: var(--feue-secondary);
-        margin-bottom: 2px;
-    }
-
-    .feue.item .form-group input,
-    .feue.item .form-group select,
-    .feue.item .form-group textarea {
-        font-size: 11px;
-        padding: 3px 5px;
-        border: 1px solid var(--feue-border);
-        border-radius: 3px;
-    }
-
-.feue.item .stats-grid {
-    grid-template-columns: repeat(5, 1fr);
-    gap: 8px;
-    margin: 8px 0;
-}
-
-    .feue.item .stats-grid .form-group {
-        min-width: 0;
-    }
-
-        .feue.item .stats-grid .form-group input {
-            width: 100%;
-            text-align: center;
-        }
-
-/* ===== CLASS TAB SPECIFIC ===== */
-.feue.item .tab.class h4 {
-    font-size: 12px;
-    color: var(--feue-primary);
-    margin: 12px 0 6px 0;
-    border-bottom: 1px solid var(--feue-accent);
-    padding-bottom: 2px;
-}
-
-.feue.item .uses-group {
-    align-items: center;
-}
-
-    .feue.item .uses-group input {
-        width: 40px;
-    }
-
-/* ===== RESPONSIVE ADJUSTMENTS ===== */
-@media (max-width: 640px) {
-    .feue.item .stats-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
-
-    .feue.item .form-row {
-        flex-direction: column;
-    }
-}
-
-/* ===== COMBAT ARTS (add to feue.css) ===== */
-.feue .combat-arts-section {
-    background: white;
-    border: 2px solid var(--feue-border);
-    border-radius: 8px;
-    padding: 15px;
-    margin: 15px 0;
-}
-
-    .feue .combat-arts-section h3 {
-        color: var(--feue-primary);
-        font-weight: bold;
-        margin: 0 0 10px 0;
-        font-size: 14px;
-        border-bottom: 2px solid var(--feue-accent);
-        padding-bottom: 5px;
-    }
-
-.feue .combat-art-info {
-    flex: 1;
-    margin: 0 10px;
-}
-
-.feue .combat-art-details {
-    margin: 0;
-    font-size: 12px;
-    color: var(--feue-secondary);
-    font-style: italic;
-}
-
-/* Fix weapon rank row naming (was .weapon-rank, now .weapon-rank-row) */
-.feue .weapon-rank-row {
-    align-items: center;
-    gap: 8px;
-}
- 
-/* Computed stats and key values */
-.feue .computed-value {
-    font-family: var(--feue-font-gba);
-    font-size: 35px;
-    letter-spacing: 1px;
-}
-
-/* Weapon stats and badges */
-.feue .weapon-stats span {
-    font-family: var(--feue-font-gba);
-}
-
-/* Tabs for a retro Fire Emblem feel */
-.feue .tabs .item {
-    font-family: var(--feue-font-gba);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-}
-
-/* Combat roll titles and level-up messages */
-.feue-attack-roll h3,
-.feue-levelup h3 {
-    font-family: var(--feue-font-gba);
-    letter-spacing: 1px;
-}
-
-.feue .fe-gba {
-    font-family: var(--feue-font-gba);
-    letter-spacing: 1px;
-    text-transform: uppercase;
-}
-
-/* ===== PROFICIENT WEAPON RANKS ===== */
-.feue .weapon-rank.proficient {
-    background: rgba(46, 125, 50, 0.08);
-    border-radius: 4px;
-    padding: 4px 6px;
 }
 
 .feue .no-proficiency-note {
@@ -972,10 +445,10 @@
     margin: 4px 0 8px;
 }
 
-/* ===== OTHER WEAPONS COLLAPSIBLE ===== */
+/* Other Weapons (collapsible) */
 .feue .other-weapons-section {
     margin-top: 10px;
-    border-top: 1px solid rgba(139, 115, 85, 0.3);
+    border-top: 1px solid rgba(139, 115, 85, 0.25);
     padding-top: 8px;
 }
 
@@ -999,11 +472,633 @@
 }
 
 .feue .other-weapons-content .weapon-rank {
-    opacity: 0.7;
+    opacity: 0.6;
 }
 
 .feue .other-weapons-content .weapon-rank:hover {
     opacity: 1;
+}
+
+/* ===== MAIN TAB: MOVEMENT & DETAILS ===== */
+.feue .movement,
+.feue .details {
+    flex: 1;
+    margin-top: 12px;
+}
+
+.feue .movement {
+    margin-right: 12px;
+}
+
+.feue .movement h3,
+.feue .details h3 {
+    border-bottom: 2px solid var(--feue-accent);
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+}
+
+.feue .movement .resource,
+.feue .details .resource {
+    justify-content: space-between;
+    padding: 4px 0;
+}
+
+.feue .movement .resource label,
+.feue .details .resource label {
+    font-weight: bold;
+    color: var(--feue-secondary);
+    font-size: 12px;
+}
+
+.feue .movement .resource input,
+.feue .details .resource input,
+.feue .details .resource select {
+    width: 60px;
+    text-align: center;
+    border: 1px solid var(--feue-border);
+    border-radius: 3px;
+    padding: 3px 4px;
+    font-family: var(--feue-font-gba);
+    font-size: 13px;
+    background: white;
+}
+
+.feue .movement .resource input:disabled {
+    background: transparent;
+    border-color: rgba(194, 169, 106, 0.3);
+}
+
+.feue .details .resource select {
+    width: auto;
+    font-family: var(--feue-font-body);
+    font-size: 12px;
+    text-align: left;
+}
+
+/* ===== COMBAT TAB: COMBAT STATS ===== */
+.feue .combat-stats {
+    margin-bottom: 12px;
+    padding: 10px;
+    display: flex;
+    justify-content: space-around;
+    gap: 8px;
+    background: linear-gradient(135deg, var(--feue-header-bg) 0%, var(--feue-primary) 100%);
+    border-color: var(--feue-accent);
+}
+
+.feue .combat-stat {
+    text-align: center;
+    padding: 8px 6px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    min-width: 80px;
+    flex: 1;
+}
+
+.feue .combat-stat label {
+    display: block;
+    font-weight: bold;
+    color: var(--feue-secondary);
+    font-size: 10px;
+    font-family: var(--feue-font-header);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+
+.feue .computed-value {
+    font-family: var(--feue-font-gba);
+    font-size: 22px;
+    font-weight: bold;
+    color: white;
+    letter-spacing: 1px;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+/* ===== SECTION HEADERS (shared) ===== */
+.feue .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    border-bottom: 2px solid var(--feue-accent);
+    padding-bottom: 4px;
+}
+
+.feue .section-header h3 {
+    margin: 0;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+/* ===== ITEM ROWS (shared across all tabs) ===== */
+.feue .item {
+    background: rgba(255, 255, 255, 0.5);
+    border: 1px solid var(--feue-border);
+    border-radius: 4px;
+    padding: 6px 8px;
+    margin: 4px 0;
+    align-items: center;
+    transition: all 0.15s ease;
+}
+
+.feue .item:hover {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: var(--feue-secondary);
+}
+
+.feue .item-image img {
+    border: 1px solid var(--feue-border);
+    border-radius: 3px;
+}
+
+.feue .item-name {
+    flex: 1;
+    margin: 0 10px;
+    font-weight: bold;
+    color: var(--feue-text);
+    font-size: 13px;
+}
+
+.feue .item-controls {
+    display: flex;
+    gap: 3px;
+}
+
+.feue .item-control {
+    background: var(--feue-secondary);
+    color: white;
+    border: none;
+    border-radius: 3px;
+    padding: 4px 6px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    font-size: 11px;
+}
+
+.feue .item-control:hover {
+    background: #b8860b;
+}
+
+/* Add / Create buttons */
+.feue .item-create {
+    display: inline-flex;
+    gap: 5px;
+    align-items: center;
+    border: 1px solid var(--feue-primary);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    font-family: var(--feue-font-gba);
+    color: white;
+    background: linear-gradient(180deg, var(--feue-tab-active), var(--feue-primary));
+    letter-spacing: 0.3px;
+    transition: all 0.15s ease;
+}
+
+.feue .item-create:hover {
+    background: linear-gradient(180deg, #5e83b6, #2f5485);
+    text-shadow: none;
+}
+
+.feue .item-create.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.feue .limit-note,
+.feue .empty-note,
+.feue .inventory-limit p {
+    color: var(--feue-secondary);
+    font-style: italic;
+    margin: 0;
+    font-size: 12px;
+}
+
+/* ===== WEAPON STAT BADGES ===== */
+.feue .weapon-stats {
+    display: flex;
+    gap: 3px;
+    margin-right: 8px;
+    flex-wrap: wrap;
+}
+
+.feue .weapon-stats span {
+    background: var(--feue-primary);
+    color: white;
+    padding: 2px 7px;
+    border-radius: 10px;
+    font-family: var(--feue-font-gba);
+    font-size: 11px;
+    font-weight: normal;
+    line-height: 1.4;
+    white-space: nowrap;
+}
+
+/* ===== COMBAT TAB: SECTIONS ===== */
+.feue .weapons-section,
+.feue .battalion-section,
+.feue .combat-arts-section,
+.feue .items-section {
+    margin: 12px 0;
+}
+
+.feue .combat-art-info {
+    flex: 1;
+    margin: 0 10px;
+}
+
+.feue .combat-art-details {
+    margin: 0;
+    font-size: 11px;
+    color: var(--feue-secondary);
+    font-style: italic;
+}
+
+/* ===== INVENTORY TAB ===== */
+.feue .inventory-limit {
+    margin-bottom: 12px;
+}
+
+.feue .inventory-limit h3 {
+    font-family: var(--feue-font-gba);
+    font-size: 13px;
+    margin-bottom: 4px;
+}
+
+.feue .item-quantity {
+    font-family: var(--feue-font-gba);
+    font-size: 13px;
+    color: var(--feue-primary);
+    min-width: 28px;
+    text-align: center;
+    background: rgba(44, 42, 74, 0.08);
+    border-radius: 3px;
+    padding: 2px 6px;
+    margin-right: 6px;
+}
+
+.feue .item-weight {
+    font-family: var(--feue-font-gba);
+    font-size: 11px;
+    color: var(--feue-secondary);
+    min-width: 40px;
+    text-align: center;
+    margin-right: 6px;
+}
+
+/* ===== SKILLS & ABILITIES TAB ===== */
+.feue .classes-section,
+.feue .skills-section,
+.feue .spells-section {
+    flex: 1;
+    margin-bottom: 12px;
+}
+
+.feue .classes-section {
+    margin-right: 12px;
+}
+
+.feue .class-info,
+.feue .skill-info,
+.feue .spell-info {
+    flex: 1;
+    margin: 0 10px;
+}
+
+.feue .class-type,
+.feue .skill-type,
+.feue .spell-details,
+.feue .class-details {
+    margin: 0;
+    font-size: 11px;
+    color: var(--feue-secondary);
+    font-style: italic;
+}
+
+/* ===== ROLEPLAY TAB ===== */
+.feue .personal-details {
+    margin-bottom: 12px;
+}
+
+.feue .personal-details h3 {
+    text-align: center;
+    border-bottom: 2px solid var(--feue-accent);
+    padding-bottom: 6px;
+    margin-bottom: 10px;
+}
+
+.feue .details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px;
+}
+
+.feue .detail {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.feue .detail label {
+    font-weight: bold;
+    color: var(--feue-secondary);
+    font-size: 12px;
+}
+
+.feue .detail input {
+    border: 1px solid var(--feue-border);
+    border-radius: 3px;
+    padding: 4px 6px;
+    background: white;
+    font-size: 12px;
+}
+
+.feue .biography-text,
+.feue .appearance-text {
+    margin-bottom: 12px;
+}
+
+.feue .biography-text h3,
+.feue .appearance-text h3 {
+    border-bottom: 2px solid var(--feue-accent);
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+}
+
+.feue .biography-text textarea,
+.feue .appearance-text textarea {
+    width: 100%;
+    border: 1px solid var(--feue-border);
+    border-radius: 4px;
+    padding: 8px;
+    font-family: var(--feue-font-body);
+    font-size: 12px;
+    resize: vertical;
+    background: white;
+}
+
+/* ===== CHAT MESSAGES: LEVEL UP ===== */
+.feue-levelup {
+    background: linear-gradient(135deg, var(--feue-header-bg) 0%, var(--feue-primary) 100%);
+    color: white;
+    padding: 12px;
+    border-radius: 6px;
+    border: 2px solid var(--feue-accent);
+    margin: 5px 0;
+    text-align: center;
+}
+
+.feue-levelup h3 {
+    font-family: var(--feue-font-gba);
+    letter-spacing: 1px;
+    margin: 0 0 8px 0;
+    font-size: 14px;
+    color: var(--feue-secondary);
+}
+
+.feue-levelup .stat-gains {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.feue-levelup .gain {
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    padding: 3px 8px;
+    border-radius: 3px;
+    font-family: var(--feue-font-gba);
+    font-weight: bold;
+    font-size: 12px;
+    letter-spacing: 0.5px;
+}
+
+/* ===== CHAT MESSAGES: ATTACK ROLL ===== */
+.feue-attack-roll {
+    background: var(--feue-card-bg);
+    border: 2px solid var(--feue-border);
+    border-radius: 6px;
+    padding: 12px;
+    margin: 5px 0;
+}
+
+.feue-attack-roll h3 {
+    font-family: var(--feue-font-gba);
+    color: var(--feue-primary);
+    letter-spacing: 1px;
+    margin: 0 0 8px 0;
+    font-size: 13px;
+    border-bottom: 1px solid var(--feue-border);
+    padding-bottom: 6px;
+}
+
+.feue-attack-roll p {
+    margin: 4px 0;
+    font-size: 12px;
+}
+
+/* ===== ITEM SHEET: HEADER ===== */
+.feue.item .sheet-header {
+    padding: 8px 12px;
+    min-height: 60px;
+    max-height: 70px;
+}
+
+.feue.item .sheet-header .item-img {
+    width: 48px;
+    height: 48px;
+    border: 2px solid var(--feue-secondary);
+    border-radius: 4px;
+    flex-shrink: 0;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+.feue.item .sheet-header .header-fields {
+    flex: 1;
+    margin-left: 12px;
+    min-height: 0;
+}
+
+.feue.item .sheet-header .item-name {
+    margin: 0;
+}
+
+.feue.item .sheet-header .item-name input {
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    font-family: var(--feue-font-header);
+    width: 100%;
+    padding: 0;
+    margin: 0;
+}
+
+/* ===== ITEM SHEET: FORMS ===== */
+.feue .form-row {
+    display: flex;
+    gap: 12px;
+    margin: 8px 0;
+}
+
+.feue .form-group {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 4px;
+}
+
+.feue .form-group label {
+    font-weight: bold;
+    color: var(--feue-secondary);
+    font-size: 11px;
+}
+
+.feue .form-group input,
+.feue .form-group select,
+.feue .form-group textarea {
+    border: 1px solid var(--feue-border);
+    border-radius: 3px;
+    padding: 4px 6px;
+    font-size: 12px;
+    background: white;
+}
+
+.feue .uses-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.feue .uses-group input {
+    width: 45px;
+    text-align: center;
+}
+
+.feue .uses-group span {
+    font-weight: bold;
+    color: var(--feue-secondary);
+}
+
+/* Item sheet compact overrides */
+.feue.item .form-row {
+    gap: 10px;
+    margin: 6px 0;
+}
+
+.feue.item .form-group {
+    gap: 3px;
+}
+
+.feue.item .form-group label {
+    font-size: 11px;
+    margin-bottom: 1px;
+}
+
+.feue.item .form-group input,
+.feue.item .form-group select,
+.feue.item .form-group textarea {
+    font-size: 11px;
+    padding: 3px 5px;
+}
+
+.feue .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 8px;
+    margin: 8px 0;
+}
+
+.feue.item .stats-grid {
+    grid-template-columns: repeat(5, 1fr);
+}
+
+.feue.item .stats-grid .form-group {
+    min-width: 0;
+}
+
+.feue.item .stats-grid .form-group input {
+    width: 100%;
+    text-align: center;
+}
+
+/* Class tab */
+.feue.item .tab.class h4 {
+    font-size: 12px;
+    color: var(--feue-primary);
+    margin: 10px 0 6px 0;
+    border-bottom: 1px solid var(--feue-accent);
+    padding-bottom: 2px;
+}
+
+.feue.item .uses-group {
+    align-items: center;
+}
+
+.feue.item .uses-group input {
+    width: 40px;
+}
+
+.feue .class-type {
+    flex: 1;
+    margin: 0 10px;
+    color: var(--feue-text);
+}
+
+/* ===== PROMOTION TREE ===== */
+.promo-tree-list {
+    list-style: none;
+    margin: 0 0 0 14px;
+    padding: 0 0 0 12px;
+    border-left: 2px solid rgba(44, 72, 117, 0.2);
+}
+
+.promo-tree-node {
+    margin: 6px 0;
+}
+
+.promo-tree-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border: 1px solid var(--feue-border);
+    border-radius: 4px;
+    background: var(--feue-card-bg);
+    transition: all 0.15s ease;
+}
+
+.promo-tree-row:hover {
+    border-color: var(--feue-secondary);
+}
+
+.promo-tree-label {
+    flex: 1;
+}
+
+.promo-tree-type {
+    font-size: 11px;
+    opacity: 0.7;
+}
+
+.promo-tree-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+    font-size: 11px;
+    color: #2e7d32;
+    font-weight: bold;
+}
+
+.promo-tree-node.is-selected .promo-tree-row {
+    background: rgba(46, 125, 50, 0.08);
+    border-color: #2e7d32;
 }
 
 /* ===== CLASS SKILLS (Item Sheet) ===== */
@@ -1016,18 +1111,18 @@
     align-items: center;
     gap: 8px;
     padding: 4px 2px;
-    border-bottom: 1px solid rgba(139, 115, 85, 0.2);
+    border-bottom: 1px solid rgba(139, 115, 85, 0.15);
 }
 
-    .feue .class-skill-entry:last-child {
-        border-bottom: none;
-    }
+.feue .class-skill-entry:last-child {
+    border-bottom: none;
+}
 
-    .feue .class-skill-entry img {
-        border: 1px solid var(--feue-border);
-        border-radius: 3px;
-        flex-shrink: 0;
-    }
+.feue .class-skill-entry img {
+    border: 1px solid var(--feue-border);
+    border-radius: 3px;
+    flex-shrink: 0;
+}
 
 .feue .class-skill-name {
     flex: 1;
@@ -1050,9 +1145,9 @@
     flex-shrink: 0;
 }
 
-    .feue .class-skill-remove:hover {
-        color: #c0392b;
-    }
+.feue .class-skill-remove:hover {
+    color: #c0392b;
+}
 
 .feue .class-skills-empty {
     color: #8b4513;
@@ -1061,15 +1156,83 @@
     margin: 4px 0;
 }
 
-/* ===== LEVEL UP BONUS (permanent misc bonus) ===== */
+/* ===== LEVEL UP BONUS ITEM ===== */
 .feue .level-up-bonus-item {
     background: rgba(218, 165, 32, 0.08);
     border-left: 3px solid var(--feue-accent);
-    border-radius: 4px;
-    padding-left: 6px;
 }
 
-    .feue .level-up-bonus-item .item-name {
-        font-weight: bold;
-        color: var(--feue-accent);
+.feue .level-up-bonus-item .item-name {
+    font-weight: bold;
+    color: var(--feue-accent);
+}
+
+/* ===== UTILITY CLASSES ===== */
+.feue .flexrow {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.feue .flexcol {
+    display: flex;
+    flex-direction: column;
+}
+
+.feue .flex {
+    flex: 1;
+}
+
+.feue .text-center {
+    text-align: center;
+}
+
+.feue .fe-gba {
+    font-family: var(--feue-font-gba);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 800px) {
+    .feue .sheet-header {
+        flex-direction: column;
+        text-align: center;
     }
+
+    .feue .flexrow {
+        flex-direction: column;
+    }
+
+    .feue .attributes,
+    .feue .growth-rates,
+    .feue .classes-section,
+    .feue .skills-section {
+        margin-right: 0;
+        margin-bottom: 12px;
+    }
+
+    .feue .movement {
+        margin-right: 0;
+    }
+
+    .feue .combat-stats {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .feue .weapon-ranks-grid,
+    .feue .details-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .feue.item .stats-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .feue.item .form-row {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
Structural fixes:
- Fix .growth-grid → .growth-rates-grid (grid had no styling before!)
- Consolidate all duplicate/scattered rule blocks into single definitions
- Remove stale "add to feue.css" comment and unused .weapon-rank-row class
- Organize rules logically by sheet section instead of scattered additions

Readability improvements:
- Tab font: 28px/0.5 line-height → 13px/1.4 (was unreadably cramped)
- Computed combat values: 35px → 22px (was overflowing stat boxes)
- Weapon stat badges: 20px/font-weight:50 → 11px/normal (50 is invalid)
- Item control buttons: 1px gap → 3px (no longer mashed together)
- Alternating row backgrounds on attribute/growth rate grids
- Disabled inputs now visually distinct (transparent bg, faded border)

Missing styles added:
- .hp-fields, .hp-current, .hp-max (HP display in header)
- .header-row (header layout)
- .item-quantity, .item-weight (inventory badges)
- .movement, .details sections (were unstyled cards)
- Proper .attribute-value span styling

Fire Emblem aesthetic enhancements:
- Warm parchment card backgrounds (--feue-card-bg) with subtle shadows
- Combat stat boxes: dark indigo panel with gold labels (like FE stat screens)
- Profile image: gold border with drop shadow
- Level Up button: gradient with GBA font styling
- Section headers: consistent gold accent underlines
- HP value styled green (GBA health color)
- Gold border highlight on item row hover
- Chat messages: border accent, better heading treatment

https://claude.ai/code/session_01JdZ76Mu6HdTuyiUcfp8J1C