### PR TITLE
Fix rulebook compliance bugs and add missing sheet components

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -15,7 +15,7 @@ const FEUE = {
         "S": { order: 5, label: "S" }
     },
     AFFINITIES: ["Fire", "Thunder", "Wind", "Ice", "Earth", "Dark", "Light", "Anima"],
-    UNIT_TYPES: ["Infantry", "Mounted", "Flying", "Dragon", "Armored", "Magician", "Beast", "Monster"],
+    UNIT_TYPES: ["Infantry", "Mounted", "Flying", "Dragon", "Armored", "Magician", "Beast", "Mechanical", "Monster"],
     CLASS_TYPES: ["Recruit", "Standard", "Promoted", "Advanced", "Enemy Only"],
     MAG_WEAPON_TYPES: ["anima", "light", "dark", "staff", "stone"],
     STAT_KEYS: ["hp", "strength", "magic", "skill", "speed", "defense", "resistance", "luck", "charm", "build"],
@@ -54,10 +54,16 @@ class FireEmblemActor extends Actor {
 
     _collectBonuses() {
         const totals = this._blankBonuses();
-        const bonusItems = this.items.filter(i =>
-            ["item", "skill"].includes(i.type) ||
-            (i.type === "miscBonus" && i.system?.enabled !== false)
-        );
+        const bonusItems = this.items.filter(i => {
+            if (i.type === "skill") return true;
+            if (i.type === "item") {
+                // Equippable items only grant bonuses when equipped
+                if (i.system.itemType === "equippable") return i.system.equipped === true;
+                return true; // Consumables always apply their bonuses (if any)
+            }
+            if (i.type === "miscBonus" && i.system?.enabled !== false) return true;
+            return false;
+        });
         const equippedWeapon = this.items.find(i => i.type === "weapon" && i.system?.equipped);
         if (equippedWeapon) bonusItems.push(equippedWeapon);
         for (const item of bonusItems) {
@@ -179,6 +185,23 @@ class FireEmblemActor extends Actor {
 
         const baseHitRate = skl + Math.floor(lck / 4) + (bonus.combat.hitRate || 0);
         const baseCritRate = Math.floor(skl / 2) + (bonus.combat.critRate || 0);
+
+        // Damage: weapon might + relevant stat
+        let damage = 0;
+        if (ew) {
+            const di = this.getDamageStat(ew.system.weaponType);
+            damage = Number(ew.system.might || 0) + di.value;
+        }
+
+        // Aid: depends on unit type and sex
+        const unitTypes = Array.isArray(system.unitTypes) ? system.unitTypes : [];
+        const sex = (system.personalDetails?.sex || "").toLowerCase();
+        const isMountedOrFlying = unitTypes.some(t => ["Mounted", "Flying"].includes(t));
+        let aid = Math.max(bld - 1, 0); // Infantry default
+        if (isMountedOrFlying) {
+            aid = (sex === "female" || sex === "f") ? (20 - bld) : (25 - bld);
+        }
+
         system.combat = {
             attackSpeed: as,
             baseHitRate,
@@ -186,7 +209,9 @@ class FireEmblemActor extends Actor {
             hitRate: baseHitRate + wHit,
             critRate: baseCritRate + wCrit,
             avoid: spd + Math.floor(lck / 4) + (bonus.combat.avoid || 0),
-            dodge: lck + (bonus.combat.dodge || 0)
+            dodge: lck + (bonus.combat.dodge || 0),
+            damage,
+            aid
         };
     }
 
@@ -213,48 +238,75 @@ class FireEmblemActor extends Actor {
 
         // ── Normal level up ──
         const gr = system.growthRates || {};
+        const accumulated = foundry.utils.deepClone(system.accumulatedGrowthRates || {});
         const gains = {};
+        const newAccumulated = {};
+        const rollDetails = [];
 
-        for (const [stat, growth] of Object.entries(gr)) {
-            const roll = await new Roll("1d10").evaluate();
-            gains[stat] = (roll.total <= growth) ? 1 : 0;
-        }
+        for (const stat of FEUE.STAT_KEYS) {
+            const baseGR = Number(gr[stat] || 0);
+            const accum = Number(accumulated[stat] || 0);
+            const effectiveGR = baseGR + accum;
 
-        // Enforce stat caps — skip gains for stats already at max
-        for (const [stat, gained] of Object.entries(gains)) {
-            if (!gained) continue;
+            // Check stat cap first
+            let atCap = false;
             if (stat === "hp") {
-                const ecHp = this.items.find(i => i.type === "class" && i.system?.equipped);
-                if (ecHp) {
-                    const nodeHp = this._getCurrentClassNode(ecHp);
+                if (ec) {
+                    const nodeHp = this._getCurrentClassNode(ec);
                     const hpCap = Number(nodeHp.statCaps?.hp || 0);
-                    if (hpCap > 0 && Number(this.system.attributes?.hp?.max || 0) >= hpCap) {
-                        gains[stat] = 0;
-                    }
+                    if (hpCap > 0 && Number(system.attributes?.hp?.max || 0) >= hpCap) atCap = true;
                 }
+            } else {
+                const currentVal = Number(system.attributes?.[stat]?.value || 0);
+                const cap = Number(system.attributes?.[stat]?.max || 0);
+                if (cap > 0 && currentVal >= cap) atCap = true;
+            }
+
+            if (atCap) {
+                gains[stat] = 0;
+                newAccumulated[stat] = 0;
+                rollDetails.push({ stat, roll: "—", effectiveGR, gained: 0, atCap: true });
                 continue;
             }
-            const currentVal = Number(this.system.attributes?.[stat]?.value || 0);
-            const cap = Number(this.system.attributes?.[stat]?.max || 0);
-            if (cap > 0 && currentVal >= cap) {
-                gains[stat] = 0;  // Already at cap
+
+            if (effectiveGR >= 10) {
+                // Guaranteed +1, plus +1 per additional 10 above threshold
+                const gained = 1 + Math.floor((effectiveGR - 10) / 10);
+                gains[stat] = gained;
+                newAccumulated[stat] = effectiveGR % 10;
+                rollDetails.push({ stat, roll: "auto", effectiveGR, gained, atCap: false });
+            } else {
+                const roll = await new Roll("1d10").evaluate();
+                const sum = roll.total + effectiveGR;
+                if (sum >= 10) {
+                    gains[stat] = 1;
+                    newAccumulated[stat] = 0;
+                    rollDetails.push({ stat, roll: roll.total, effectiveGR, gained: 1, atCap: false });
+                } else {
+                    gains[stat] = 0;
+                    newAccumulated[stat] = sum;
+                    rollDetails.push({ stat, roll: roll.total, effectiveGR, gained: 0, atCap: false, carried: sum });
+                }
             }
         }
+
+        // Persist accumulated growth rates
+        await this.update({ "system.accumulatedGrowthRates": newAccumulated });
 
         const gainedStats = Object.entries(gains).filter(([, v]) => v > 0);
 
         if (gainedStats.length) {
             const bonusItem = await this._getOrCreateLevelUpBonus();
             const updates = {};
-            for (const [stat] of gainedStats) {
+            for (const [stat, amount] of gainedStats) {
                 const current = Number(bonusItem.system.bonuses?.attributes?.[stat] || 0);
-                updates[`system.bonuses.attributes.${stat}`] = current + 1;
+                updates[`system.bonuses.attributes.${stat}`] = current + amount;
             }
             await bonusItem.update(updates);
 
             if (gains.hp) {
                 await this.update({
-                    "system.attributes.hp.value": (system.attributes?.hp?.value || 0) + 1
+                    "system.attributes.hp.value": (system.attributes?.hp?.value || 0) + gains.hp
                 });
             }
         }
@@ -262,10 +314,21 @@ class FireEmblemActor extends Actor {
         const newLevel = currentLevel + 1;
         await this.update({ "system.level": newLevel, "system.totalLevel": (system.totalLevel || 1) + 1 });
 
-        const gainList = Object.entries(gains).filter(([, v]) => v > 0).map(([k]) => FEUE.STAT_LABELS[k] || k);
+        // Build detailed chat message
+        const detailRows = rollDetails.map(d => {
+            const label = FEUE.STAT_LABELS[d.stat] || d.stat;
+            if (d.atCap) return `<tr><td>${label}</td><td colspan="3" style="color:#888;">At cap</td></tr>`;
+            const rollStr = d.roll === "auto" ? "Auto" : String(d.roll);
+            const resultStr = d.gained > 0
+                ? `<span class="gain">+${d.gained}</span>`
+                : (d.carried ? `<span style="color:#b8860b;">Carry ${d.carried}</span>` : `<span style="color:#888;">—</span>`);
+            return `<tr><td>${label}</td><td>${rollStr}</td><td>GR ${d.effectiveGR}</td><td>${resultStr}</td></tr>`;
+        }).join("");
+
+        const gainList = gainedStats.map(([k, v]) => `<span class="gain">+${v} ${FEUE.STAT_LABELS[k] || k}</span>`);
         ChatMessage.create({
             user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: this }),
-            content: `<div class="feue-levelup"><h3>${this.name} reached level ${newLevel}!</h3>${gainList.length ? `<div class="stat-gains">${gainList.map(s => `<span class="gain">+1 ${s}</span>`).join("")}</div>` : "<p>No stats increased.</p>"}</div>`
+            content: `<div class="feue-levelup"><h3>${this.name} reached level ${newLevel}!</h3>${gainList.length ? `<div class="stat-gains">${gainList.join("")}</div>` : "<p>No stats increased.</p>"}<details><summary>Roll Details</summary><table class="feue-gr-table"><tr><th>Stat</th><th>Roll</th><th>GR</th><th>Result</th></tr>${detailRows}</table></details></div>`
         });
 
         // Grant class skills for new level
@@ -484,6 +547,24 @@ class FireEmblemActor extends Actor {
         }
     }
 
+    _onUpdate(changed, options, userId) {
+        super._onUpdate(changed, options, userId);
+        if (game.user.id !== userId) return;
+
+        // Auto-level when EXP reaches 10+
+        const newExp = foundry.utils.getProperty(changed, "system.experience");
+        if (newExp !== undefined && newExp >= 10) {
+            // Count how many level-ups are earned (every 10 EXP = 1 level)
+            const levelUps = Math.floor(newExp / 10);
+            // EXP always resets to 0 per rulebook (no carrying remainder)
+            this.update({ "system.experience": 0 }).then(async () => {
+                for (let i = 0; i < levelUps; i++) {
+                    await this.levelUp();
+                }
+            });
+        }
+    }
+
     canUseWeapon(weapon) {
         if (!weapon?.system?.weaponType || !weapon?.system?.rank) return true;
         const r = this.system.weaponRanks?.[weapon.system.weaponType] || "";
@@ -631,6 +712,17 @@ class FireEmblemCharacterSheet extends ActorSheet {
             await item.update({ "system.equipped": true });
         });
 
+        html.find(".item-control.item-equip").click(async ev => {
+            const id = $(ev.currentTarget).closest(".item").data("item-id");
+            const item = this.actor.items.get(id);
+            if (!item) return;
+            if (item.system.equipped) { await item.update({ "system.equipped": false }); return; }
+            // Unequip other equippable items first (only one equipped at a time)
+            const others = this.actor.items.filter(i => i.type === "item" && i.system.itemType === "equippable" && i.system.equipped && i.id !== item.id);
+            if (others.length) await this.actor.updateEmbeddedDocuments("Item", others.map(i => ({ _id: i.id, "system.equipped": false })));
+            await item.update({ "system.equipped": true });
+        });
+
         html.find(".roll-attack").click(async (ev) => this._onRollAttack(ev));
         html.find(".roll-battalion").click(async (ev) => this._onRollBattalion(ev));
         html.find(".roll-spell").click(async (ev) => this._onRollSpell(ev));
@@ -658,17 +750,37 @@ class FireEmblemCharacterSheet extends ActorSheet {
         event.preventDefault();
         const weapon = this.actor.items.get(event.currentTarget.dataset.weaponId);
         if (!weapon) return;
-        if (!this.actor.canUseWeapon(weapon)) return ui.notifications.warn("Insufficient weapon rank.");
-        if (weapon.system.uses?.value <= 0) return ui.notifications.warn("Weapon is broken.");
-        const a = this.actor, di = a.getDamageStat(weapon.system.weaponType), dmg = Number(weapon.system.might || 0) + di.value;
-        const hr = a.system.combat?.hitRate || 0, cr = a.system.combat?.critRate || 0;
+
+        const a = this.actor;
+        const isBroken = (weapon.system.uses?.value ?? 1) <= 0;
+        const isNonProf = !a.canUseWeapon(weapon);
+        const penalties = [];
+
+        // Determine modifiers based on weapon state
+        let mightMult = 1, hitMult = 1, critOverride = null;
+        if (isBroken) {
+            mightMult = 0; hitMult = 0.5; critOverride = 0;
+            penalties.push("BROKEN");
+        } else if (isNonProf) {
+            mightMult = 0.5; hitMult = 0.5; critOverride = 0;
+            penalties.push("NON-PROFICIENT");
+        }
+
+        const di = a.getDamageStat(weapon.system.weaponType);
+        const baseMight = isBroken ? 0 : Number(weapon.system.might || 0);
+        const dmg = Math.floor((baseMight + di.value) * mightMult);
+        const hr = Math.floor((a.system.combat?.hitRate || 0) * hitMult);
+        const cr = critOverride !== null ? critOverride : (a.system.combat?.critRate || 0);
+
         const hR = await new Roll("1d100").evaluate(); const hit = hR.total <= hr;
         let crit = false; if (hit && cr > 0) { const cR = await new Roll("1d100").evaluate(); crit = cR.total <= cr; }
         if (weapon.system.uses) await weapon.update({ "system.uses.value": Math.max(weapon.system.uses.value - 1, 0) });
         const fd = crit ? dmg * 3 : dmg;
+
+        const penaltyNote = penalties.length ? `<p class="feue-penalty"><b>${penalties.join(", ")}</b> — penalties applied</p>` : "";
         ChatMessage.create({
             user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: a }),
-            content: `<div class="feue-attack-roll"><h3>${a.name} attacks with ${weapon.name}!</h3><p><b>Hit:</b> ${hR.total} vs ${hr}% — <b>${hit ? "HIT" : "MISS"}</b></p>${hit && cr > 0 ? `<p><b>Crit:</b> ${crit ? "CRITICAL HIT!" : "Normal Hit"}</p>` : ""}${hit ? `<p><b>Damage:</b> ${fd} (${weapon.system.might} Mt + ${di.value} ${di.stat}${crit ? " × 3" : ""})</p>` : ""}<p><b>Range:</b> ${weapon.system.range}</p></div>`
+            content: `<div class="feue-attack-roll"><h3>${a.name} attacks with ${weapon.name}!</h3>${penaltyNote}<p><b>Hit:</b> ${hR.total} vs ${hr}% — <b>${hit ? "HIT" : "MISS"}</b></p>${hit && cr > 0 ? `<p><b>Crit:</b> ${crit ? "CRITICAL HIT!" : "Normal Hit"}</p>` : ""}${hit ? `<p><b>Damage:</b> ${fd} (${baseMight} Mt + ${di.value} ${di.stat}${mightMult !== 1 ? ` × ${mightMult}` : ""}${crit ? " × 3" : ""})</p>` : ""}<p><b>Range:</b> ${weapon.system.range}</p></div>`
         });
     }
 
@@ -724,16 +836,27 @@ class FireEmblemCharacterSheet extends ActorSheet {
     async _executeCombatArt(art, weapon) {
         const a = this.actor, dc = Number(art.system.durabilityCost || 0), uses = weapon.system.uses;
         if (uses && dc > 0 && uses.value < dc) return ui.notifications.warn(`Not enough durability on ${weapon.name}.`);
-        const di = a.getDamageStat(weapon.system.weaponType), dmg = Number(weapon.system.might || 0) + di.value;
-        const hr = (a.system.combat?.baseHitRate || 0) + Number(weapon.system.hit || 0);
-        const cr = (a.system.combat?.baseCritRate || 0) + Number(weapon.system.crit || 0);
+
+        const di = a.getDamageStat(weapon.system.weaponType);
+        const artMt = Number(art.system.might || 0);
+        const artHit = Number(art.system.hit || 0);
+        const artCrit = Number(art.system.crit || 0);
+
+        const dmg = Number(weapon.system.might || 0) + di.value + artMt;
+        const hr = (a.system.combat?.baseHitRate || 0) + Number(weapon.system.hit || 0) + artHit;
+        const cr = (a.system.combat?.baseCritRate || 0) + Number(weapon.system.crit || 0) + artCrit;
+
         const hR = await new Roll("1d100").evaluate(); const hit = hR.total <= hr;
         let crit = false; if (hit && cr > 0) { const cR = await new Roll("1d100").evaluate(); crit = cR.total <= cr; }
         if (uses && dc > 0) await weapon.update({ "system.uses.value": Math.max(uses.value - dc, 0) });
         const fd = crit ? dmg * 3 : dmg;
+
+        const dmgParts = [`${weapon.system.might} Mt`, `${di.value} ${di.stat}`];
+        if (artMt) dmgParts.push(`${artMt > 0 ? "+" : ""}${artMt} Art`);
+
         ChatMessage.create({
             user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: a }),
-            content: `<div class="feue-attack-roll"><h3>${a.name} uses ${art.name} with ${weapon.name}!</h3><p><b>Hit:</b> ${hR.total} vs ${hr}% — <b>${hit ? "HIT" : "MISS"}</b></p>${hit && cr > 0 ? `<p><b>Crit:</b> ${crit ? "CRITICAL HIT!" : "Normal Hit"}</p>` : ""}${hit ? `<p><b>Damage:</b> ${fd} (${weapon.system.might} Mt + ${di.value} ${di.stat}${crit ? " × 3" : ""})</p>` : ""}<p><b>Effect:</b> ${art.system.effect || "—"} | <b>Dur Cost:</b> ${dc}</p></div>`
+            content: `<div class="feue-attack-roll"><h3>${a.name} uses ${art.name} with ${weapon.name}!</h3><p><b>Hit:</b> ${hR.total} vs ${hr}%${artHit ? ` (incl. ${artHit > 0 ? "+" : ""}${artHit} Art)` : ""} — <b>${hit ? "HIT" : "MISS"}</b></p>${hit && cr > 0 ? `<p><b>Crit:</b> ${crit ? "CRITICAL HIT!" : "Normal Hit"}${artCrit ? ` (incl. ${artCrit > 0 ? "+" : ""}${artCrit} Art)` : ""}</p>` : ""}${hit ? `<p><b>Damage:</b> ${fd} (${dmgParts.join(" + ")}${crit ? " × 3" : ""})</p>` : ""}<p><b>Effect:</b> ${art.system.effect || "—"} | <b>Dur Cost:</b> ${dc}</p></div>`
         });
     }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -64,6 +64,7 @@
       "armored": "Armored",
       "magician": "Magician",
       "beast": "Beast",
+      "mechanical": "Mechanical",
       "monster": "Monster"
     },
     "Affinities": {

--- a/template.json
+++ b/template.json
@@ -57,6 +57,18 @@
           "charm": 0,
           "build": 0
         },
+        "accumulatedGrowthRates": {
+          "hp": 0,
+          "strength": 0,
+          "magic": 0,
+          "skill": 0,
+          "speed": 0,
+          "defense": 0,
+          "resistance": 0,
+          "luck": 0,
+          "charm": 0,
+          "build": 0
+        },
         "level": 1,
         "totalLevel": 1,
         "experience": 0
@@ -95,6 +107,7 @@
       "unitTypes": [],
       "supportRanks": {},
       "affinity": "",
+      "weaponExp": 0,
       "fatePoints": {
         "value": 0,
         "max": 0
@@ -175,6 +188,7 @@
     "item": {
       "templates": [ "base", "physical" ],
       "itemType": "consumable",
+      "equipped": false,
       "uses": {
         "value": 3,
         "max": 3
@@ -216,6 +230,11 @@
       "prerequisites": "",
       "weaponRestriction": "—",
       "durabilityCost": 1,
+      "might": 0,
+      "hit": 0,
+      "crit": 0,
+      "avoid": 0,
+      "dodge": 0,
       "effect": ""
     },
     "skill": {

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -23,6 +23,12 @@
                     </div>
                     <button type="button" class="level-up">Level Up</button>
                 </div>
+                <div class="resource flexrow">
+                    <div class="resource-label">Total Lv</div>
+                    <div class="resource-value">
+                        <span>{{actor.system.totalLevel}}</span>
+                    </div>
+                </div>
             </div>
             <div class="resource flexrow">
                 <div class="resource-label">Class</div>
@@ -161,11 +167,13 @@
         {{!-- Combat Tab --}}
         <div class="tab combat" data-group="primary" data-tab="combat" data-drop-target="true">
             <div class="combat-stats flexrow">
+                <div class="combat-stat"><label>Damage</label><span class="computed-value">{{actor.system.combat.damage}}</span></div>
                 <div class="combat-stat"><label>Attack Speed</label><span class="computed-value">{{actor.system.combat.attackSpeed}}</span></div>
                 <div class="combat-stat"><label>Hit Rate</label><span class="computed-value">{{actor.system.combat.hitRate}}%</span></div>
                 <div class="combat-stat"><label>Critical Rate</label><span class="computed-value">{{actor.system.combat.critRate}}%</span></div>
                 <div class="combat-stat"><label>Avoid</label><span class="computed-value">{{actor.system.combat.avoid}}%</span></div>
                 <div class="combat-stat"><label>Dodge</label><span class="computed-value">{{actor.system.combat.dodge}}%</span></div>
+                <div class="combat-stat"><label>Aid</label><span class="computed-value">{{actor.system.combat.aid}}</span></div>
             </div>
 
             <div class="weapons-section">
@@ -218,7 +226,16 @@
                 {{#each combatArts as |art|}}
                 <div class="item combat-art flexrow" data-item-id="{{art._id}}">
                     <div class="item-image"><img src="{{art.img}}" title="{{art.name}}" width="24" height="24" /></div>
-                    <div class="combat-art-info"><h4 class="item-name">{{art.name}}</h4><p class="combat-art-details">{{art.system.durabilityCost}} Dur | {{art.system.effect}}</p></div>
+                    <div class="combat-art-info">
+                        <h4 class="item-name">{{art.name}}</h4>
+                        <p class="combat-art-details">
+                            {{art.system.durabilityCost}} Dur
+                            {{#if art.system.might}} | +{{art.system.might}} Mt{{/if}}
+                            {{#if art.system.hit}} | +{{art.system.hit}} Hit{{/if}}
+                            {{#if art.system.crit}} | +{{art.system.crit}} Crit{{/if}}
+                            {{#if art.system.effect}} | {{art.system.effect}}{{/if}}
+                        </p>
+                    </div>
                     <div class="item-controls">
                         <a class="item-control roll-combat-art" data-item-id="{{art._id}}" title="Use"><i class="fas fa-dice-d20"></i></a>
                         <a class="item-control item-edit" title="Edit"><i class="fas fa-edit"></i></a>
@@ -244,6 +261,9 @@
                     <div class="item-quantity">{{item.system.quantity}}</div>
                     <div class="item-weight">{{item.system.weight}} wt</div>
                     <div class="item-controls">
+                        {{#ifEquals item.system.itemType "equippable"}}
+                        <a class="item-control item-equip" title="{{#if item.system.equipped}}Unequip{{else}}Equip{{/if}}"><i class="fas {{#if item.system.equipped}}fa-shield-alt{{else}}fa-hand-paper{{/if}}"></i></a>
+                        {{/ifEquals}}
                         <a class="item-control item-edit" title="Edit"><i class="fas fa-edit"></i></a>
                         <a class="item-control item-delete" title="Delete"><i class="fas fa-trash"></i></a>
                     </div>

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -175,6 +175,16 @@
                 </div>
             </div>
             <div class="form-group"><label>Durability Cost</label><input type="number" data-dtype="Number" name="system.durabilityCost" value="{{item.system.durabilityCost}}" placeholder="0" min="0" /></div>
+            <div class="form-row">
+                <div class="form-group"><label>Might Bonus</label><input type="number" data-dtype="Number" name="system.might" value="{{item.system.might}}" placeholder="0" /></div>
+                <div class="form-group"><label>Hit Bonus</label><input type="number" data-dtype="Number" name="system.hit" value="{{item.system.hit}}" placeholder="0" /></div>
+                <div class="form-group"><label>Crit Bonus</label><input type="number" data-dtype="Number" name="system.crit" value="{{item.system.crit}}" placeholder="0" /></div>
+            </div>
+            <div class="form-row">
+                <div class="form-group"><label>Avoid Bonus</label><input type="number" data-dtype="Number" name="system.avoid" value="{{item.system.avoid}}" placeholder="0" /></div>
+                <div class="form-group"><label>Dodge Bonus</label><input type="number" data-dtype="Number" name="system.dodge" value="{{item.system.dodge}}" placeholder="0" /></div>
+            </div>
+            <div class="form-group"><label>Prerequisites</label><input type="text" name="system.prerequisites" value="{{item.system.prerequisites}}" placeholder="e.g. STR 13, any D" /></div>
             <div class="form-group"><label>Effects</label><textarea name="system.effect" rows="2" placeholder="Effect...">{{item.system.effect}}</textarea></div>
         </div>
         {{/if}}


### PR DESCRIPTION
## Summary

Audited the full 181-page **Fire Emblem: Ultimate Edition v1.0** Core Rulebook against the current FoundryVTT system implementation. This PR fixes 5 bugs where the system contradicted the rulebook and adds 6 high-impact missing sheet components.

### Bug Fixes
- **Growth rate formula was wrong**: Changed from `roll <= GR` to `roll + GR >= 10` per rulebook p.6. Also implements the carry-over mechanic (missed rolls accumulate toward next level) and guaranteed +1 at GR 10+
- **Combat arts ignored their stat bonuses**: `_executeCombatArt` now adds the art's Mt/Hit/Crit bonuses to calculations. Chat messages show the art bonus breakdown
- **Broken weapons blocked attacks entirely**: Now usable with penalties (Might=0, Hit halved, Crit=0) per rulebook p.105
- **Non-proficient weapons blocked attacks entirely**: Now usable with penalties (Might halved, Hit halved, Crit=0) per rulebook p.104
- **Missing "Mechanical" unit type**: Added to match the 9 unit types in the rulebook (p.20)

### New Sheet Components
- **Total Level** displayed in header (was tracked internally but never shown)
- **Damage stat** (Weapon Mt + STR/MAG/SPD) computed and shown on combat tab
- **Aid stat** calculated from Build/unit type/sex per rulebook rescue rules
- **Combat art stat fields** (Mt/Hit/Crit/Avo/Dge/Prerequisites) in item sheet and character sheet display
- **Equipment item equip system**: Equippable items now have toggle, only grant bonuses when equipped, one-at-a-time enforced
- **EXP auto-level trigger**: Reaching 10+ EXP resets to 0 and triggers levelUp(), supports multi-level gains

### Data Model Changes (template.json)
- `accumulatedGrowthRates` on Actor base (growth rate carry-over)
- `might/hit/crit/avoid/dodge` on combatArt items
- `weaponExp` on character (groundwork for future WEXP UI)
- `equipped` on item type (for equippable items)

## Test plan
- [ ] Create a test character with a class, level up multiple times — verify growth rolls use `roll + GR >= 10` and carry-over accumulates on misses
- [ ] Create a combat art with +5 Mt, +10 Hit — use it in combat and verify bonuses in chat
- [ ] Set a weapon to 0 uses — attack with it and verify BROKEN penalties in chat
- [ ] Equip a weapon above your rank — attack and verify NON-PROFICIENT penalties
- [ ] Verify Damage, Aid, and Total Level display on combat tab and header
- [ ] Create an equippable item with stat bonuses — verify stats change on equip/unequip
- [ ] Set EXP to 9, add 1 — verify auto-level triggers and EXP resets to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)