### PR TITLE
Add Prf weapon rank with per-weapon proficiency toggle

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -807,6 +807,7 @@ class FireEmblemActor extends Actor {
     canUseWeapon(weapon) {
         if (!weapon?.system?.weaponType || !weapon?.system?.rank) return true;
         if (this._hasHolyBloodForWeapon(weapon?.name)) return true;
+        if (weapon.system.rank === "Prf") return !!weapon.system.prfProficient;
         const r = this.system.weaponRanks?.[weapon.system.weaponType] || "";
         if (!r) return false;
         return FEUE.WEAPON_RANKS[r].order >= FEUE.WEAPON_RANKS[weapon.system.rank].order;

--- a/template.json
+++ b/template.json
@@ -219,6 +219,7 @@
       "crit": 0,
       "range": "1",
       "rank": "E",
+      "prfProficient": false,
       "uses": {
         "value": 45,
         "max": 45

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -102,8 +102,13 @@
         <div class="tab weapon" data-group="primary" data-tab="weapon">
             <div class="form-row">
                 <div class="form-group"><label>Weapon Type</label><select name="system.weaponType">{{#each FEUE.WeaponTypes as |label key|}}<option value="{{key}}" {{#ifEquals ../item.system.weaponType key}} selected{{/ifEquals}}>{{label}}</option>{{/each}}</select></div>
-                <div class="form-group"><label>Weapon Rank</label><select name="system.rank">{{#each FEUE.WEAPON_RANKS as |rd rk|}}{{#unless (eq rk "")}}<option value="{{rk}}" {{#ifEquals ../item.system.rank rk}} selected{{/ifEquals}}>{{rd.label}}</option>{{/unless}}{{/each}}</select></div>
+                <div class="form-group"><label>Weapon Rank</label><select name="system.rank">{{#each FEUE.WEAPON_RANKS as |rd rk|}}{{#unless (eq rk "")}}<option value="{{rk}}" {{#ifEquals ../item.system.rank rk}} selected{{/ifEquals}}>{{rd.label}}</option>{{/unless}}{{/each}}<option value="Prf" {{#ifEquals item.system.rank "Prf"}} selected{{/ifEquals}}>Prf</option></select></div>
             </div>
+            {{#ifEquals item.system.rank "Prf"}}
+            <div class="form-row">
+                <div class="form-group"><label>Proficient for Wielder</label><input type="checkbox" name="system.prfProficient" {{checked item.system.prfProficient}} /></div>
+            </div>
+            {{/ifEquals}}
             <div class="form-row">
                 <div class="form-group"><label>Might</label><input type="number" data-dtype="Number" name="system.might" value="{{item.system.might}}" placeholder="0" /></div>
                 <div class="form-group"><label>Hit Rate</label><input type="number" data-dtype="Number" name="system.hit" value="{{item.system.hit}}" placeholder="0" /></div>


### PR DESCRIPTION
## Summary
- Adds `Prf` as a selectable weapon rank on the weapon item sheet
- Adds a "Proficient for Wielder" checkbox shown only when rank is `Prf` — the GM flips this on to authorize whoever currently holds the weapon
- Fixes `canUseWeapon` so Prf-ranked weapons no longer hit an undefined lookup in `FEUE.WEAPON_RANKS`

## Why
Prf had a localization label but no real plumbing — any weapon set to rank `Prf` would silently fail the proficiency check. This wires it up as a proper per-weapon gate.

## Behavior
- Default: a Prf-ranked weapon is unusable by anyone
- GM toggles `prfProficient` on the weapon to allow the current holder to wield it
- Holy Blood bearers still get automatic access to their bloodline weapon regardless of the toggle

## Test plan
- [ ] Create a weapon, set rank to `Prf`, confirm the checkbox appears
- [ ] With the checkbox off, confirm the owning character cannot use the weapon (shown as non-proficient in combat)
- [ ] Toggle the checkbox on, confirm the character can use the weapon
- [ ] Confirm a Holy Blood bearer can wield their bloodline's Prf weapon even with the checkbox off
- [ ] Confirm non-Prf weapons continue to use the normal E/D/C/B/A/S rank comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)