### PR TITLE
Make Staff weapons heal instead of damage

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -1479,6 +1479,8 @@ class FireEmblemCharacterSheet extends ActorSheet {
         const weapon = this.actor.items.get(event.currentTarget.dataset.weaponId);
         if (!weapon) return;
 
+        if (weapon.system.weaponType === "staff") return this._useStaff(weapon);
+
         const target = this._getTarget();
         const buildPreview = (tri) => {
             const s = this._computeAttackStats(weapon, tri, target);
@@ -1658,6 +1660,89 @@ class FireEmblemCharacterSheet extends ActorSheet {
             user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: a }),
             content: `<div class="feue-attack-roll"><h3>${a.name} casts ${sp.name}${target ? ` on ${target.name}` : ""}!</h3>${admixNote}${targetNote}<p><b>School:</b> ${sp.system.school} | <b>HP Cost:</b> ${cost}${admix ? ` (base ${baseCost})` : ""}</p><p><b>Hit:</b> ${hR.total} vs ${netHit}%${target ? ` (${rawHit} - ${tAvo} Avo)` : ""}${admix ? ` (incl. +${admixHit} Admix)` : ""} — <b>${hit ? "HIT" : "MISS"}</b></p>${hit && netCrit > 0 ? `<p><b>Crit:</b> ${crit ? "CRITICAL HIT!" : "Normal Hit"}${admix ? ` (incl. +${admixCrit} Admix)` : ""}</p>` : ""}${hit ? `<p><b>Damage:</b> ${fd}${target ? ` (${rawDmg} - ${tRes} Res${crit ? " × 3" : ""})` : ` (${sp.system.might} Mt + ${mag} MAG${admix ? ` + ${admixMt} Admix` : ""}${crit ? " × 3" : ""})`}</p>` : ""}<p><b>Range:</b> ${sp.system.range}</p></div>`
         });
+    }
+
+    async _useStaff(weapon) {
+        const caster = this.actor;
+        const isBroken = (weapon.system.uses?.value ?? 1) <= 0;
+        const isNonProf = !caster.canUseWeapon(weapon);
+        const penalties = [];
+        let mightMult = 1, hitMult = 1;
+        if (isBroken) { mightMult = 0; hitMult = 0.5; penalties.push("BROKEN"); }
+        else if (isNonProf) { mightMult = 0.5; hitMult = 0.5; penalties.push("NON-PROFICIENT"); }
+
+        const mag = caster.system.attributes?.magic?.value || 0;
+        const baseMight = isBroken ? 0 : Number(weapon.system.might || 0);
+        const healing = Math.max(Math.floor((baseMight + mag) * mightMult), 0);
+        const weaponHit = Number(weapon.system.hit || 0);
+        const needsHitRoll = weaponHit > 0;
+        const rawHit = needsHitRoll ? Math.max(Math.floor(((caster.system.combat?.hitRate || 0) + weaponHit) * hitMult), 0) : 0;
+
+        const targetOptions = [`<option value="self">Self (${caster.name})</option>`];
+        if (typeof canvas !== "undefined" && canvas.tokens?.placeables) {
+            for (const token of canvas.tokens.placeables) {
+                if (token.actor && token.actor.id !== caster.id) {
+                    targetOptions.push(`<option value="${token.actor.id}">${token.actor.name}</option>`);
+                }
+            }
+        }
+
+        const penaltyLine = penalties.length ? `<p style="color:red;"><b>${penalties.join(", ")}</b></p>` : "";
+        const hitLine = needsHitRoll ? `<p>Hit: <b>${rawHit}%</b></p>` : "";
+
+        new Dialog({
+            title: `Use ${weapon.name}`,
+            content: `<form>
+                ${penaltyLine}
+                <div class="form-group"><label>Target</label><select id="staff-target">${targetOptions.join("")}</select></div>
+                <p>Healing: <b>${healing}</b> HP (${baseMight} Mt + ${mag} MAG${mightMult !== 1 ? ` × ${mightMult}` : ""})</p>
+                ${hitLine}
+            </form>`,
+            buttons: {
+                use: {
+                    icon: '<i class="fas fa-heart"></i>', label: "Use",
+                    callback: async (h) => {
+                        const targetId = h.find("#staff-target").val();
+                        const target = targetId === "self" ? caster : game.actors.get(targetId);
+                        if (!target) return;
+
+                        let hit = true, hitRollTotal = null;
+                        if (needsHitRoll) {
+                            const tAvo = target.system?.combat?.avoid || 0;
+                            const netHit = Math.max(rawHit - tAvo, 0);
+                            const hR = await new Roll("1d100").evaluate();
+                            hitRollTotal = hR.total;
+                            hit = hR.total <= netHit;
+                        }
+
+                        if (weapon.system.uses) {
+                            const newUses = Math.max(weapon.system.uses.value - 1, 0);
+                            await weapon.update({ "system.uses.value": newUses });
+                            if (newUses > 0 && newUses <= 2) ui.notifications.warn(`${weapon.name} has only ${newUses} use(s) remaining!`);
+                        }
+
+                        let healed = 0, tHp = 0, newHp = 0;
+                        if (hit) {
+                            tHp = target.system.attributes?.hp?.value || 0;
+                            const tMax = target.system.attributes?.hp?.max || 0;
+                            newHp = Math.min(tHp + healing, tMax);
+                            healed = newHp - tHp;
+                            await target.update({ "system.attributes.hp.value": newHp });
+                        }
+
+                        const penaltyNote = penalties.length ? `<p class="feue-penalty"><b>${penalties.join(", ")}</b> — penalties applied</p>` : "";
+                        const hitNote = needsHitRoll ? `<p><b>Hit:</b> ${hitRollTotal} vs ${rawHit}% — <b>${hit ? "HIT" : "MISS"}</b></p>` : "";
+                        const healNote = hit ? `<p><b>Healed:</b> ${healed} HP (${tHp} → ${newHp})</p>` : "";
+                        ChatMessage.create({
+                            user: game.user.id, speaker: ChatMessage.getSpeaker({ actor: caster }),
+                            content: `<div class="feue-heal-roll"><h3>${caster.name} uses ${weapon.name} on ${target.name}!</h3>${penaltyNote}${hitNote}${healNote}<p><b>Range:</b> ${weapon.system.range}</p></div>`
+                        });
+                    }
+                },
+                cancel: { label: "Cancel" }
+            },
+            default: "use"
+        }).render(true);
     }
 
     async _castHealingSpell(sp, caster, mag, admixMt, cost, baseCost, admix, admixWeapon) {

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -255,13 +255,17 @@
                     <div class="item-image"><img src="{{weapon.img}}" title="{{weapon.name}}" width="24" height="24" /></div>
                     <h4 class="item-name">{{weapon.name}}</h4>
                     <div class="weapon-stats">
+                        {{#ifEquals weapon.system.weaponType "staff"}}
+                        <span>{{weapon.system.might}} Heal</span>{{#if weapon.system.hit}}<span>{{weapon.system.hit}}% Hit</span>{{/if}}<span>{{weapon.system.range}} Rng</span>
+                        {{else}}
                         <span>{{weapon.system.might}} Mt</span><span>{{weapon.system.hit}}% Hit</span>
                         <span>{{weapon.system.crit}}% Crit</span><span>{{weapon.system.range}} Rng</span>
+                        {{/ifEquals}}
                         {{#if weapon.system.uses.max}}<span class="weapon-uses">({{weapon.system.uses.value}}/{{weapon.system.uses.max}})</span>{{/if}}
                     </div>
                     <div class="item-controls">
                         <a class="item-control weapon-equip" title="{{#if weapon.system.equipped}}Unequip{{else}}Equip{{/if}}"><i class="fas {{#if weapon.system.equipped}}fa-shield-alt{{else}}fa-hand-paper{{/if}}"></i></a>
-                        <a class="item-control roll-attack" data-weapon-id="{{weapon._id}}" title="Attack"><i class="fas fa-dice-d10"></i></a>
+                        <a class="item-control roll-attack" data-weapon-id="{{weapon._id}}" title="{{#ifEquals weapon.system.weaponType "staff"}}Use Staff{{else}}Attack{{/ifEquals}}"><i class="fas {{#ifEquals weapon.system.weaponType "staff"}}fa-heart{{else}}fa-dice-d10{{/ifEquals}}"></i></a>
                         <a class="item-control item-edit" title="Edit"><i class="fas fa-edit"></i></a>
                         <a class="item-control item-delete" title="Delete"><i class="fas fa-trash"></i></a>
                     </div>

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -110,9 +110,11 @@
             </div>
             {{/ifEquals}}
             <div class="form-row">
-                <div class="form-group"><label>Might</label><input type="number" data-dtype="Number" name="system.might" value="{{item.system.might}}" placeholder="0" /></div>
-                <div class="form-group"><label>Hit Rate</label><input type="number" data-dtype="Number" name="system.hit" value="{{item.system.hit}}" placeholder="0" /></div>
+                <div class="form-group"><label>{{#ifEquals item.system.weaponType "staff"}}Healing{{else}}Might{{/ifEquals}}</label><input type="number" data-dtype="Number" name="system.might" value="{{item.system.might}}" placeholder="0" /></div>
+                <div class="form-group"><label>Hit Rate{{#ifEquals item.system.weaponType "staff"}} <span style="opacity:0.6;font-size:10px;">(optional)</span>{{/ifEquals}}</label><input type="number" data-dtype="Number" name="system.hit" value="{{item.system.hit}}" placeholder="0" /></div>
+                {{#unless (eq item.system.weaponType "staff")}}
                 <div class="form-group"><label>Crit Rate</label><input type="number" data-dtype="Number" name="system.crit" value="{{item.system.crit}}" placeholder="0" /></div>
+                {{/unless}}
             </div>
             <div class="form-row">
                 <div class="form-group"><label>Range</label><input type="text" name="system.range" value="{{item.system.range}}" placeholder="1" /></div>


### PR DESCRIPTION
## Summary
- Staff weapons now trigger a heal flow (target picker, Healing = Mt + MAG, consumes 1 use) instead of the standard attack. Hit roll is skipped when the weapon's Hit Rate is 0.
- Item sheet: "Might" label becomes "Healing" for staves, Hit Rate is marked optional, Crit Rate is hidden.
- Character sheet weapon row: staves show "Heal" instead of "Mt", hide Crit, omit Hit when 0, and use a heart icon with a "Use Staff" tooltip.

## Why
Previously, staves were listed under `MAG_WEAPON_TYPES` and went through `_onRollAttack`, which rolled damage against the target's RES — not how staves work in Fire Emblem. Broken/non-proficient penalties still apply to healing.

## Test plan
- [ ] Create a Staff weapon on a character — confirm the item sheet shows "Healing" (not Might) and no Crit field.
- [ ] Click the heart icon on the weapon row; confirm the target dialog lists Self + other tokens and shows `Healing = Mt + MAG`.
- [ ] Use a staff with Hit Rate = 0 → no hit roll in chat; HP of target increases (clamped to max).
- [ ] Use a staff with Hit Rate > 0 → chat shows a hit roll; miss suppresses healing.
- [ ] Confirm a use is consumed each cast and the low-uses warning fires.
- [ ] Equip a non-proficient staff → NON-PROFICIENT penalty applies and healing halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)