### PR TITLE
Tidy item sheet: conditional Weight/Quantity and collapsible bonuses

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -2205,6 +2205,9 @@ class FireEmblemItemSheet extends ItemSheet {
         data.FEUE = FEUE;
         data.properPromotionEnabled = (game.settings?.get("feue", "properPromotion") || "off") !== "off";
         data.isPromotionItem = !!this.item.getFlag("feue", "isPromotionItem");
+        const t = this.item.type, s = this.item.system || {};
+        data.showQuantity = t !== "weapon";
+        data.showWeight = (t === "weapon" && s.weaponType !== "staff") || (t === "item" && s.itemType === "equippable");
         return data;
     }
 
@@ -2214,6 +2217,14 @@ class FireEmblemItemSheet extends ItemSheet {
         html.find("input, select, textarea").change(ev => this._saveField(ev));
         html.find("input[name='flags.feue.isPromotionItem']").change(async (ev) => {
             await this.item.setFlag("feue", "isPromotionItem", ev.currentTarget.checked);
+        });
+        html.find(".bonus-toggle").click(ev => {
+            ev.preventDefault();
+            const section = $(ev.currentTarget).closest(".feue-bonus-section");
+            section.toggleClass("collapsed");
+            const label = section.hasClass("collapsed") ? "Show All" : "Hide";
+            const icon = section.hasClass("collapsed") ? "fa-chevron-down" : "fa-chevron-up";
+            $(ev.currentTarget).html(`<i class="fas ${icon}"></i> ${label}`);
         });
 
         if (this.item.type === "class") {

--- a/styles/feue.css
+++ b/styles/feue.css
@@ -1643,3 +1643,18 @@
     border: 1px dashed #b8a080; border-radius: 4px;
     background: rgba(139, 115, 85, 0.05);
 }
+
+/* Collapsible bonus sections on item sheets */
+.feue-bonus-section .bonus-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 4px;
+}
+.feue-bonus-section .bonus-header h3 { margin: 0; }
+.feue-bonus-section .bonus-toggle {
+    cursor: pointer; font-size: 11px; color: #2c4875;
+    padding: 2px 8px; border: 1px solid #b8a080; border-radius: 4px;
+    background: rgba(139, 115, 85, 0.1);
+}
+.feue-bonus-section .bonus-toggle:hover { background: rgba(139, 115, 85, 0.25); }
+.feue-bonus-section.collapsed .bonus-zero { display: none; }
+.feue-bonus-section.collapsed .form-row:not(:has(.form-group:not(.bonus-zero))) { display: none; }

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -29,70 +29,83 @@
             {{#unless (eq item.type "skill")}}{{#unless (eq item.type "spell")}}{{#unless (eq item.type "class")}}{{#unless (eq item.type "combatArt")}}{{#unless (eq item.type "miscBonus")}}
             <div class="form-row">
                 <div class="form-group"><label>Price</label><input type="number" data-dtype="Number" name="system.price" value="{{item.system.price}}" placeholder="0" min="0" /></div>
+                {{#if showWeight}}
                 <div class="form-group"><label>Weight</label><input type="number" data-dtype="Number" name="system.weight" value="{{item.system.weight}}" placeholder="0" min="0" /></div>
+                {{/if}}
+                {{#if showQuantity}}
                 <div class="form-group"><label>Quantity</label><input type="number" data-dtype="Number" name="system.quantity" value="{{item.system.quantity}}" placeholder="1" min="0" /></div>
+                {{/if}}
             </div>
             {{/unless}}{{/unless}}{{/unless}}{{/unless}}{{/unless}}
 
-            <div class="form-group">
-                <h3>Stat Bonuses (if any)</h3>
-                <div class="form-row">
-                    <div class="form-group"><label>MaxHP</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.hp" value="{{item.system.bonuses.attributes.hp}}" placeholder="0" /></div>
-                    <div class="form-group"><label>STR</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.strength" value="{{item.system.bonuses.attributes.strength}}" placeholder="0" /></div>
-                    <div class="form-group"><label>MAG</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.magic" value="{{item.system.bonuses.attributes.magic}}" placeholder="0" /></div>
-                    <div class="form-group"><label>SKL</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.skill" value="{{item.system.bonuses.attributes.skill}}" placeholder="0" /></div>
-                    <div class="form-group"><label>SPD</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.speed" value="{{item.system.bonuses.attributes.speed}}" placeholder="0" /></div>
+            <div class="form-group feue-bonus-section collapsed">
+                <div class="bonus-header">
+                    <h3>Stat Bonuses</h3>
+                    <a class="bonus-toggle"><i class="fas fa-chevron-down"></i> Show All</a>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label>DEF</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.defense" value="{{item.system.bonuses.attributes.defense}}" placeholder="0" /></div>
-                    <div class="form-group"><label>RES</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.resistance" value="{{item.system.bonuses.attributes.resistance}}" placeholder="0" /></div>
-                    <div class="form-group"><label>LUK</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.luck" value="{{item.system.bonuses.attributes.luck}}" placeholder="0" /></div>
-                    <div class="form-group"><label>CHA</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.charm" value="{{item.system.bonuses.attributes.charm}}" placeholder="0" /></div>
-                    <div class="form-group"><label>BLD</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.build" value="{{item.system.bonuses.attributes.build}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.hp}}bonus-zero{{/unless}}"><label>MaxHP</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.hp" value="{{item.system.bonuses.attributes.hp}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.strength}}bonus-zero{{/unless}}"><label>STR</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.strength" value="{{item.system.bonuses.attributes.strength}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.magic}}bonus-zero{{/unless}}"><label>MAG</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.magic" value="{{item.system.bonuses.attributes.magic}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.skill}}bonus-zero{{/unless}}"><label>SKL</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.skill" value="{{item.system.bonuses.attributes.skill}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.speed}}bonus-zero{{/unless}}"><label>SPD</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.speed" value="{{item.system.bonuses.attributes.speed}}" placeholder="0" /></div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label>MOVE</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.move" value="{{item.system.bonuses.attributes.move}}" placeholder="0" /></div>
-                    <div class="form-group"><label>Hit Rate</label><input type="number" data-dtype="Number" name="system.bonuses.combat.hitRate" value="{{item.system.bonuses.combat.hitRate}}" placeholder="0" /></div>
-                    <div class="form-group"><label>Crit Rate</label><input type="number" data-dtype="Number" name="system.bonuses.combat.critRate" value="{{item.system.bonuses.combat.critRate}}" placeholder="0" /></div>
-                    <div class="form-group"><label>Avoid</label><input type="number" data-dtype="Number" name="system.bonuses.combat.avoid" value="{{item.system.bonuses.combat.avoid}}" placeholder="0" /></div>
-                    <div class="form-group"><label>Dodge</label><input type="number" data-dtype="Number" name="system.bonuses.combat.dodge" value="{{item.system.bonuses.combat.dodge}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.defense}}bonus-zero{{/unless}}"><label>DEF</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.defense" value="{{item.system.bonuses.attributes.defense}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.resistance}}bonus-zero{{/unless}}"><label>RES</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.resistance" value="{{item.system.bonuses.attributes.resistance}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.luck}}bonus-zero{{/unless}}"><label>LUK</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.luck" value="{{item.system.bonuses.attributes.luck}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.charm}}bonus-zero{{/unless}}"><label>CHA</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.charm" value="{{item.system.bonuses.attributes.charm}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.build}}bonus-zero{{/unless}}"><label>BLD</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.build" value="{{item.system.bonuses.attributes.build}}" placeholder="0" /></div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label>Attack Speed</label><input type="number" data-dtype="Number" name="system.bonuses.combat.attackSpeed" value="{{item.system.bonuses.combat.attackSpeed}}" placeholder="0" /></div>
-                </div>
-            </div>
-            <div class="form-group">
-                <h3>Stat Cap Bonuses (if any)</h3>
-                <div class="form-row">
-                    <div class="form-group"><label>MaxHP</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.hp" value="{{item.system.bonuses.maximums.hp}}" placeholder="0" /></div>
-                    <div class="form-group"><label>STR</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.strength" value="{{item.system.bonuses.maximums.strength}}" placeholder="0" /></div>
-                    <div class="form-group"><label>MAG</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.magic" value="{{item.system.bonuses.maximums.magic}}" placeholder="0" /></div>
-                    <div class="form-group"><label>SKL</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.skill" value="{{item.system.bonuses.maximums.skill}}" placeholder="0" /></div>
-                    <div class="form-group"><label>SPD</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.speed" value="{{item.system.bonuses.maximums.speed}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.attributes.move}}bonus-zero{{/unless}}"><label>MOVE</label><input type="number" data-dtype="Number" name="system.bonuses.attributes.move" value="{{item.system.bonuses.attributes.move}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.combat.hitRate}}bonus-zero{{/unless}}"><label>Hit Rate</label><input type="number" data-dtype="Number" name="system.bonuses.combat.hitRate" value="{{item.system.bonuses.combat.hitRate}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.combat.critRate}}bonus-zero{{/unless}}"><label>Crit Rate</label><input type="number" data-dtype="Number" name="system.bonuses.combat.critRate" value="{{item.system.bonuses.combat.critRate}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.combat.avoid}}bonus-zero{{/unless}}"><label>Avoid</label><input type="number" data-dtype="Number" name="system.bonuses.combat.avoid" value="{{item.system.bonuses.combat.avoid}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.combat.dodge}}bonus-zero{{/unless}}"><label>Dodge</label><input type="number" data-dtype="Number" name="system.bonuses.combat.dodge" value="{{item.system.bonuses.combat.dodge}}" placeholder="0" /></div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label>DEF</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.defense" value="{{item.system.bonuses.maximums.defense}}" placeholder="0" /></div>
-                    <div class="form-group"><label>RES</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.resistance" value="{{item.system.bonuses.maximums.resistance}}" placeholder="0" /></div>
-                    <div class="form-group"><label>LUK</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.luck" value="{{item.system.bonuses.maximums.luck}}" placeholder="0" /></div>
-                    <div class="form-group"><label>CHA</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.charm" value="{{item.system.bonuses.maximums.charm}}" placeholder="0" /></div>
-                    <div class="form-group"><label>BLD</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.build" value="{{item.system.bonuses.maximums.build}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.combat.attackSpeed}}bonus-zero{{/unless}}"><label>Attack Speed</label><input type="number" data-dtype="Number" name="system.bonuses.combat.attackSpeed" value="{{item.system.bonuses.combat.attackSpeed}}" placeholder="0" /></div>
                 </div>
             </div>
-            <div class="form-group">
-                <h3>Growth Rate Bonuses (if any)</h3>
-                <div class="form-row">
-                    <div class="form-group"><label>HP</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.hp" value="{{item.system.bonuses.growthRates.hp}}" placeholder="0" /></div>
-                    <div class="form-group"><label>STR</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.strength" value="{{item.system.bonuses.growthRates.strength}}" placeholder="0" /></div>
-                    <div class="form-group"><label>MAG</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.magic" value="{{item.system.bonuses.growthRates.magic}}" placeholder="0" /></div>
-                    <div class="form-group"><label>SKL</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.skill" value="{{item.system.bonuses.growthRates.skill}}" placeholder="0" /></div>
-                    <div class="form-group"><label>SPD</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.speed" value="{{item.system.bonuses.growthRates.speed}}" placeholder="0" /></div>
+            <div class="form-group feue-bonus-section collapsed">
+                <div class="bonus-header">
+                    <h3>Stat Cap Bonuses</h3>
+                    <a class="bonus-toggle"><i class="fas fa-chevron-down"></i> Show All</a>
                 </div>
                 <div class="form-row">
-                    <div class="form-group"><label>DEF</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.defense" value="{{item.system.bonuses.growthRates.defense}}" placeholder="0" /></div>
-                    <div class="form-group"><label>RES</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.resistance" value="{{item.system.bonuses.growthRates.resistance}}" placeholder="0" /></div>
-                    <div class="form-group"><label>LUK</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.luck" value="{{item.system.bonuses.growthRates.luck}}" placeholder="0" /></div>
-                    <div class="form-group"><label>CHA</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.charm" value="{{item.system.bonuses.growthRates.charm}}" placeholder="0" /></div>
-                    <div class="form-group"><label>BLD</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.build" value="{{item.system.bonuses.growthRates.build}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.hp}}bonus-zero{{/unless}}"><label>MaxHP</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.hp" value="{{item.system.bonuses.maximums.hp}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.strength}}bonus-zero{{/unless}}"><label>STR</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.strength" value="{{item.system.bonuses.maximums.strength}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.magic}}bonus-zero{{/unless}}"><label>MAG</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.magic" value="{{item.system.bonuses.maximums.magic}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.skill}}bonus-zero{{/unless}}"><label>SKL</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.skill" value="{{item.system.bonuses.maximums.skill}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.speed}}bonus-zero{{/unless}}"><label>SPD</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.speed" value="{{item.system.bonuses.maximums.speed}}" placeholder="0" /></div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group {{#unless item.system.bonuses.maximums.defense}}bonus-zero{{/unless}}"><label>DEF</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.defense" value="{{item.system.bonuses.maximums.defense}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.resistance}}bonus-zero{{/unless}}"><label>RES</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.resistance" value="{{item.system.bonuses.maximums.resistance}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.luck}}bonus-zero{{/unless}}"><label>LUK</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.luck" value="{{item.system.bonuses.maximums.luck}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.charm}}bonus-zero{{/unless}}"><label>CHA</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.charm" value="{{item.system.bonuses.maximums.charm}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.maximums.build}}bonus-zero{{/unless}}"><label>BLD</label><input type="number" data-dtype="Number" name="system.bonuses.maximums.build" value="{{item.system.bonuses.maximums.build}}" placeholder="0" /></div>
+                </div>
+            </div>
+            <div class="form-group feue-bonus-section collapsed">
+                <div class="bonus-header">
+                    <h3>Growth Rate Bonuses</h3>
+                    <a class="bonus-toggle"><i class="fas fa-chevron-down"></i> Show All</a>
+                </div>
+                <div class="form-row">
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.hp}}bonus-zero{{/unless}}"><label>HP</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.hp" value="{{item.system.bonuses.growthRates.hp}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.strength}}bonus-zero{{/unless}}"><label>STR</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.strength" value="{{item.system.bonuses.growthRates.strength}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.magic}}bonus-zero{{/unless}}"><label>MAG</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.magic" value="{{item.system.bonuses.growthRates.magic}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.skill}}bonus-zero{{/unless}}"><label>SKL</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.skill" value="{{item.system.bonuses.growthRates.skill}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.speed}}bonus-zero{{/unless}}"><label>SPD</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.speed" value="{{item.system.bonuses.growthRates.speed}}" placeholder="0" /></div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.defense}}bonus-zero{{/unless}}"><label>DEF</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.defense" value="{{item.system.bonuses.growthRates.defense}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.resistance}}bonus-zero{{/unless}}"><label>RES</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.resistance" value="{{item.system.bonuses.growthRates.resistance}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.luck}}bonus-zero{{/unless}}"><label>LUK</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.luck" value="{{item.system.bonuses.growthRates.luck}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.charm}}bonus-zero{{/unless}}"><label>CHA</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.charm" value="{{item.system.bonuses.growthRates.charm}}" placeholder="0" /></div>
+                    <div class="form-group {{#unless item.system.bonuses.growthRates.build}}bonus-zero{{/unless}}"><label>BLD</label><input type="number" data-dtype="Number" name="system.bonuses.growthRates.build" value="{{item.system.bonuses.growthRates.build}}" placeholder="0" /></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Hide the Quantity field on weapons (weapons use durability via Uses, not stack count).
- Hide the Weight field except on non-staff weapons and equippable items; staves and other non-equip items no longer show Weight.
- Collapse Stat Bonuses, Stat Cap Bonuses, and Growth Rate Bonuses by default. A Show All / Hide toggle per section expands them, and any field with a non-zero value stays visible even when collapsed so existing bonuses are still discoverable.

## Why
The description tab was showing a lot of zeroed-out fields and irrelevant inventory controls on every item. Values are preserved regardless of collapse state — nothing is deactivated or reset.

## Test plan
- [ ] Open a non-staff weapon → Weight visible, Quantity hidden.
- [ ] Open a Staff weapon → both Weight and Quantity hidden.
- [ ] Open an "equippable" Item → Weight visible, Quantity visible.
- [ ] Open a "consumable" Item → Weight hidden, Quantity visible.
- [ ] Open a battalion → Weight hidden, Quantity visible.
- [ ] On an item with a +5 DEF Stat Bonus, confirm the DEF field is the only bonus shown when collapsed; click Show All to reveal the rest, and Hide to collapse again. Values persist across toggles and reopens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)