### PR TITLE
Add notes textarea and preserve legacy weapon properties text

### DIFF
--- a/feue.js
+++ b/feue.js
@@ -2506,6 +2506,20 @@ class FireEmblemItemSheet extends ItemSheet {
         data.showQuantity = t !== "weapon";
         data.showWeight = (t === "weapon" && s.weaponType !== "staff") || (t === "item" && s.itemType === "equippable");
         data.hidePrice = t === "weapon" && (s.properties?.illegal || s.properties?.legendary);
+
+        // One-time migration: if legacy weapon has a string/array properties field, move text to propertiesNotes
+        if (t === "weapon") {
+            const raw = this.item._source?.system?.properties;
+            if (raw != null && (typeof raw === "string" || Array.isArray(raw))) {
+                const legacyText = typeof raw === "string" ? raw : raw.filter(v => typeof v === "string").join(", ");
+                const update = { "system.properties": normalizeWeaponProperties(null) };
+                if (legacyText && !this.item._source?.system?.propertiesNotes) {
+                    update["system.propertiesNotes"] = legacyText;
+                    data.item.system.propertiesNotes = legacyText;
+                }
+                this.item.update(update);
+            }
+        }
         return data;
     }
 
@@ -2590,11 +2604,17 @@ class FireEmblemItemSheet extends ItemSheet {
 
         const update = { [el.name]: value };
 
-        // Migrate legacy array/string shape of weapon properties before nested writes
+        // Migrate legacy array/string shape of weapon properties before nested writes.
+        // Preserve any prior free-form text into system.propertiesNotes.
         if (this.item.type === "weapon" && el.name.startsWith("system.properties.")) {
             const raw = this.item._source?.system?.properties;
             if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-                await this.item.update({ "system.properties": normalizeWeaponProperties(null) });
+                const migration = { "system.properties": normalizeWeaponProperties(null) };
+                const legacyText = typeof raw === "string" ? raw : (Array.isArray(raw) ? raw.filter(v => typeof v === "string").join(", ") : "");
+                if (legacyText && !this.item._source?.system?.propertiesNotes) {
+                    migration["system.propertiesNotes"] = legacyText;
+                }
+                await this.item.update(migration);
             }
         }
 

--- a/template.json
+++ b/template.json
@@ -248,6 +248,7 @@
         "puncture": false,
         "piercing": false
       },
+      "propertiesNotes": "",
       "weaponTriangle": {
         "advantage": "—",
         "disadvantage": "—"

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -164,6 +164,7 @@
                 </div>
                 {{/if}}
             </div>
+            <div class="form-group"><label>Additional Properties / Notes</label><textarea name="system.propertiesNotes" rows="2" placeholder="Any other properties or notes...">{{item.system.propertiesNotes}}</textarea></div>
         </div>
         {{/if}}
 


### PR DESCRIPTION
## Summary
Follow-up to #33. Adds a free-form "Additional Properties / Notes" textarea on the weapon sheet alongside the structured checkboxes, and migrates any pre-existing text from the old `system.properties` textarea into it so legacy weapons don't lose their descriptions.

## What changed
- New `system.propertiesNotes` string field on weapons, rendered as a textarea under the checkbox grid.
- On sheet open, if a weapon's `system.properties` is still a legacy string/array, the text is copied into `system.propertiesNotes` and the field is normalized to the new object shape.
- Same migration runs as a guard in `_saveField` before any nested `system.properties.*` write, so checkbox toggles can't clobber old text either.

## Test plan
- [ ] Open an existing weapon that previously had text in the Weapon Properties textarea — the text appears in the new "Additional Properties / Notes" field.
- [ ] Toggle a property checkbox on that same weapon — text remains intact.
- [ ] Edit the notes textarea on a new weapon — persists correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)