### PR TITLE
Register item compendium packs in system.json

### DIFF
--- a/system.json
+++ b/system.json
@@ -38,7 +38,64 @@
   "styles": [
     "styles/feue.css"
   ],
-  "packs": [],
+  "packs": [
+    {
+      "name": "battalion",
+      "label": "Battalion",
+      "path": "packs/battalion",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "classes",
+      "label": "Classes",
+      "path": "packs/classes",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "combat-arts",
+      "label": "Combat Arts",
+      "path": "packs/combat-arts",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "consumables",
+      "label": "Consumables",
+      "path": "packs/consumables",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "equippable-items",
+      "label": "Equippable Items",
+      "path": "packs/equippable-items",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "skills",
+      "label": "Skills",
+      "path": "packs/skills",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "spell",
+      "label": "Spell",
+      "path": "packs/spell",
+      "type": "Item",
+      "system": "feue"
+    },
+    {
+      "name": "weapons",
+      "label": "Weapons",
+      "path": "packs/weapons",
+      "type": "Item",
+      "system": "feue"
+    }
+  ],
   "languages": [
     {
       "lang": "en",


### PR DESCRIPTION
## Summary
- Declares the eight Item compendiums under `packs/` (Battalion, Classes, Combat Arts, Consumables, Equippable Items, Skills, Spell, Weapons) in `system.json` so Foundry loads them with the system.

## Test plan
- [ ] Launch Foundry, load a world using the feue system, and confirm all eight compendiums appear in the Compendium Packs sidebar.
- [ ] Open each compendium and verify items load without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)